### PR TITLE
DD-209: warn if vault bag is part of a sequence

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
@@ -31,7 +31,7 @@ case class BagInfo(userId: String, created: String, uuid: UUID, bagName: String,
 object BagInfo {
   val baseUrnKey = "Base-Urn"
 
-  def apply(bagDir: File, bagInfo: Metadata, requireBaseUrnWithVersionOf: Boolean): Try[BagInfo] = Try {
+  def apply(bagDir: File, bagInfo: Metadata): Try[BagInfo] = Try {
     def getMaybe(key: String) = Option(bagInfo.get(key))
       .flatMap(_.asScala.headOption)
 
@@ -41,9 +41,6 @@ object BagInfo {
 
     val maybeVersionOf = getMaybe(DansV0Bag.IS_VERSION_OF_KEY).map(uuidFromVersionOf)
     val maybeBaseUrn = getMaybe(baseUrnKey)
-
-    if (maybeVersionOf.isDefined && requireBaseUrnWithVersionOf && maybeBaseUrn.isEmpty)
-      throw notFound(baseUrnKey)
 
     new BagInfo(
       userId = getMandatory(DansV0Bag.EASY_USER_ACCOUNT_KEY),

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -73,6 +73,8 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("dataverse.bag-id", "urn:uuid:" + bagInfo.uuid)
           addProperty("dataverse.nbn", nbn)
         case FEDORA =>
+          if (bagInfo.versionOf.isDefined && bagInfo.baseUrn.isEmpty)
+            throw InvalidBagException(s"bag-info.txt should have the ${ BagInfo.baseUrnKey } of ${ bagInfo.versionOf }")
           addProperty("dataverse.nbn", bagInfo.baseUrn.getOrElse(urn))
         case _ =>
       }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -40,7 +40,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
       .getOrElse(throw InvalidBagException("no fedoraID"))
       .text
 
-    def nbn = bagInfo.versionOf.map(
+    lazy val baseUrnFromBagIndex = bagInfo.versionOf.map(
       configuration.bagIndex.getURN(_).unsafeGetOrThrow
     ).getOrElse(urn)
 
@@ -71,7 +71,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("bag-store.bag-id", bagInfo.uuid)
           addProperty("dataverse.sword-token", bagInfo.versionOf.getOrElse(bagInfo.uuid))
           addProperty("dataverse.bag-id", "urn:uuid:" + bagInfo.uuid)
-          addProperty("dataverse.nbn", nbn)
+          addProperty("dataverse.nbn", baseUrnFromBagIndex)
         case FEDORA =>
           if (bagInfo.versionOf.isDefined && bagInfo.baseUrn.isEmpty)
             throw InvalidBagException(s"bag-info.txt should have the ${ BagInfo.baseUrnKey } of ${ bagInfo.versionOf }")
@@ -86,7 +86,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("dataverse.id-identifier", doi.replaceAll(".*/", ""))
           addProperty("dataverse.id-authority", configuration.dataverseIdAutority)
         case URN =>
-          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(urn))
+          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(baseUrnFromBagIndex))
           addProperty("dataverse.id-authority", "nbn:nl:ui:13")
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -86,7 +86,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("dataverse.id-identifier", doi.replaceAll(".*/", ""))
           addProperty("dataverse.id-authority", configuration.dataverseIdAutority)
         case URN =>
-          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(baseUrnFromBagIndex))
+          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(baseUrnFromBagIndex).replace("urn:nbn:nl:ui:13-", ""))
           addProperty("dataverse.id-authority", "nbn:nl:ui:13")
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -86,7 +86,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("dataverse.id-identifier", doi.replaceAll(".*/", ""))
           addProperty("dataverse.id-authority", configuration.dataverseIdAutority)
         case URN =>
-          addProperty("dataverse.id-identifier", urn)
+          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(urn))
           addProperty("dataverse.id-authority", "nbn:nl:ui:13")
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/EasyConvertBagToDespositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/EasyConvertBagToDespositApp.scala
@@ -41,7 +41,6 @@ class EasyConvertBagToDespositApp(configuration: Configuration) extends DebugEnh
   private def addProps(depositPropertiesFactory: DepositPropertiesFactory, maybeOutputDir: Option[File])
                       (bagParentDir: File): Try[Boolean] = {
     logger.debug(s"creating application.properties for $bagParentDir")
-    val requireBaseUrnWithVersionOf = depositPropertiesFactory.bagSource == VAULT // TODO less sneaky
     val bagInfoKeysToRemove = Seq(
       DansV0Bag.EASY_USER_ACCOUNT_KEY,
       BagInfo.baseUrnKey,
@@ -50,7 +49,7 @@ class EasyConvertBagToDespositApp(configuration: Configuration) extends DebugEnh
       bagDir <- getBagDir(bagParentDir)
       bag <- BagFacade.getBag(bagDir)
       mutableBagMetadata = bag.getMetadata
-      bagInfo <- BagInfo(bagDir, mutableBagMetadata, requireBaseUrnWithVersionOf)
+      bagInfo <- BagInfo(bagDir, mutableBagMetadata)
       _ = logger.debug(s"$bagInfo")
       ddmFile = bagDir / "metadata" / "dataset.xml"
       ddmIn <- loadXml(ddmFile)

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -60,8 +60,13 @@ class AppSpec extends AnyFlatSpec with Matchers with AppConfigSupport with FileS
     srcDir / ".." / "deposit.properties" shouldNot exist
 
     val delegate = mock[MockBagIndex]
+    val noBaseBagUUID = "87151a3a-12ed-426a-94f2-97313c7ae1f2"
     (delegate.execute(_: String)) expects s"/bag-sequence?contains=$validUUID" returning
       new HttpResponse[String]("123", 200, Map.empty)
+    (delegate.execute(_: String)) expects s"/bag-sequence?contains=$noBaseBagUUID" returning
+      new HttpResponse[String]("123", 200, Map.empty)
+    (delegate.execute(_: String)) expects s"/bags/4722d09d-e431-4899-904c-0733cd773034" returning
+      new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn></bag-info></result>", 200, Map.empty)
     val appConfig = testConfig(delegatingBagIndex(delegate))
 
     new EasyConvertBagToDespositApp(appConfig).addPropsToBags(

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -76,8 +76,8 @@ class AppSpec extends AnyFlatSpec with Matchers with AppConfigSupport with FileS
     ) shouldBe Success("No fatal errors")
 
     // post condition
-    targetDir / ".." / "deposit.properties" should exist
-    // other changes verified in other test
+    (targetDir / ".." / "deposit.properties").contentAsString should include ("dataverse.id-identifier = dans-2xg-umq8")
+    // other details verified in other test, note that the DOI has no prefix
 
     // TODO (manually) intercept logging: the bag names should reflect the errors
     //  no variation in bag-info.txt not found or a property in that file not found

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
@@ -26,10 +26,28 @@ import scala.util.{ Failure, Success }
 
 class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
 
+
+  "getSeqLength" should "return 1" in {
+    val uuid = UUID.randomUUID()
+    mockBagIndexRespondsWith(body = uuid.toString, code = 200)
+      .getSeqLength(uuid) shouldBe Success(1)
+  }
+
+  it should "return 3" in {
+    val uuid = UUID.randomUUID()
+    mockBagIndexRespondsWith(body =
+      s"""c01d7876-8080-4597-81fe-9083b5463cc1
+        | $uuid
+        |
+        |ef5d6285-c835-4199-9ae8-72cf9407b81c
+        |""".stripMargin, code = 200)
+      .getSeqLength(uuid) shouldBe Success(3)
+  }
+
   "getURN" should "report not found" in {
     val uuid = UUID.randomUUID()
     mockBagIndexRespondsWith(body = "", code = 404)
-      .getURN(uuid) shouldBe Failure(InvalidBagException(s"$uuid not found in bag-index"))
+      .getURN(uuid) shouldBe Failure(InvalidBagException(s"/bags/$uuid returned not found in bag-index"))
   }
 
   it should "return URN" in {
@@ -67,13 +85,13 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     val uuid = UUID.randomUUID()
     mockBagIndexThrows(new IOException("mocked"))
       .getURN(uuid) should matchPattern {
-      case Failure(BagIndexException(msg, _)) if msg == s"$uuid mocked" =>
+      case Failure(BagIndexException(msg, _)) if msg == s"/bags/$uuid mocked" =>
     }
   }
 
   it should "report not expected response code" in {
     val uuid = UUID.randomUUID()
     mockBagIndexRespondsWith(body = "", code = 300)
-      .getURN(uuid) shouldBe Failure(BagIndexException(s"Not expected response code from bag-index. $uuid, response: 300 - ", null))
+      .getURN(uuid) shouldBe Failure(BagIndexException(s"Not expected response code from bag-index. /bags/$uuid, response: 300 - ", null))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
@@ -21,61 +21,80 @@ import java.util.UUID
 import nl.knaw.dans.easy.bag2deposit.Fixture.BagIndexSupport
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scalaj.http.HttpResponse
 
 import scala.util.{ Failure, Success }
 
 class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
 
-
   "getSeqLength" should "return 1" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body = uuid.toString, code = 200)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bag-sequence?contains=$uuid" returning
+      new HttpResponse[String](body = uuid.toString, code = 200, Map.empty)
+    delegatingBagIndex(delegate)
       .getSeqLength(uuid) shouldBe Success(1)
   }
 
   it should "return 3" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body =
-      s"""c01d7876-8080-4597-81fe-9083b5463cc1
-        | $uuid
-        |
-        |ef5d6285-c835-4199-9ae8-72cf9407b81c
-        |""".stripMargin, code = 200)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bag-sequence?contains=$uuid" returning
+      new HttpResponse[String](body =
+        s"""c01d7876-8080-4597-81fe-9083b5463cc1
+           | $uuid
+           |
+           |ef5d6285-c835-4199-9ae8-72cf9407b81c
+           |""".stripMargin, code = 200, Map.empty)
+    delegatingBagIndex(delegate)
       .getSeqLength(uuid) shouldBe Success(3)
   }
 
   "getURN" should "report not found" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body = "", code = 404)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" returning
+      new HttpResponse[String]("", 404, Map.empty)
+    delegatingBagIndex(delegate)
       .getURN(uuid) shouldBe Failure(InvalidBagException(s"/bags/$uuid returned not found in bag-index"))
   }
 
   it should "return URN" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body =
-      """<result>
-        |    <bag-info>
-        |        <bag-id>38cb3ff1-d59d-4560-a423-6f761b237a56</bag-id>
-        |        <base-id>38cb3ff1-d59d-4560-a423-6f761b237a56</base-id>
-        |        <created>2016-11-13T00:41:11.000+01:00</created>
-        |        <doi>10.80270/test-28m-zann</doi>
-        |        <urn>urn:nbn:nl:ui:13-z4-f8cm</urn>
-        |    </bag-info>
-        |</result>""".stripMargin, code = 200)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" returning
+      new HttpResponse[String](
+        """<result>
+          |    <bag-info>
+          |        <bag-id>38cb3ff1-d59d-4560-a423-6f761b237a56</bag-id>
+          |        <base-id>38cb3ff1-d59d-4560-a423-6f761b237a56</base-id>
+          |        <created>2016-11-13T00:41:11.000+01:00</created>
+          |        <doi>10.80270/test-28m-zann</doi>
+          |        <urn>urn:nbn:nl:ui:13-z4-f8cm</urn>
+          |    </bag-info>
+          |</result>""".stripMargin,
+        200,
+        Map.empty,
+      )
+    delegatingBagIndex(delegate)
       .getURN(uuid) shouldBe Success("urn:nbn:nl:ui:13-z4-f8cm")
   }
 
   it should "report missing URN" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body =
-      "<x/>".stripMargin, code = 200)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" returning
+      new HttpResponse[String]("<x/>", 200, Map.empty)
+    delegatingBagIndex(delegate)
       .getURN(uuid) shouldBe Failure(BagIndexException(s"$uuid: no URN in <x/>", null))
   }
 
   it should "report invalid XML" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body =
-      "{}".stripMargin, code = 200)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" returning
+      new HttpResponse[String]("{}", 200, Map.empty)
+    delegatingBagIndex(delegate)
       .getURN(uuid) should matchPattern {
       case Failure(BagIndexException(msg, _)) if msg == s"$uuid: Content is not allowed in prolog. RESPONSE: {}" =>
     }
@@ -83,7 +102,10 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
 
   it should "report io problem" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexThrows(new IOException("mocked"))
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" throwing new IOException("mocked")
+
+    delegatingBagIndex(delegate)
       .getURN(uuid) should matchPattern {
       case Failure(BagIndexException(msg, _)) if msg == s"/bags/$uuid mocked" =>
     }
@@ -91,7 +113,10 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
 
   it should "report not expected response code" in {
     val uuid = UUID.randomUUID()
-    mockBagIndexRespondsWith(body = "", code = 300)
+    val delegate = mock[MockBagIndex]
+    (delegate.execute(_: String)) expects s"/bags/$uuid" returning
+      new HttpResponse[String]("", 300, Map.empty)
+    delegatingBagIndex(delegate)
       .getURN(uuid) shouldBe Failure(BagIndexException(s"Not expected response code from bag-index. /bags/$uuid, response: 300 - ", null))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
@@ -29,11 +29,11 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
 
   "apply" should "succeed" in {
     val bagDir = bags / "04e638eb-3af1-44fb-985d-36af12fccb2d" / "bag-revision-1"
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe a[Success[_]] // see also FactorySpec
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe a[Success[_]] // see also FactorySpec
   }
   it should "complain about invalid uuid" in {
     val file = bags / "not-a-uuid" / "bag-name" / "bag-info.txt"
-    BagInfo(file.parent, mockBag(file.parent).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Failure(InvalidBagException(
+    BagInfo(file.parent, mockBag(file.parent).getMetadata) shouldBe Failure(InvalidBagException(
       s"Invalid UUID: $bags/not-a-uuid"
     ))
   }
@@ -41,7 +41,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val uuid = UUID.randomUUID()
     val bagDir = (testDir / s"0$uuid" / "bag-name").createDirectories()
     val file = (bagDir / "bag-info.txt").write("EASY-User-Account: user001")
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Failure(InvalidBagException(
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Failure(InvalidBagException(
       s"No Bagging-Date in $file"
     ))
   }
@@ -49,7 +49,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val uuid = UUID.randomUUID()
     val bagDir = (testDir / s"$uuid" / "bag-name").createDirectories()
     val file = (bagDir / "bag-info.txt").write("Created: 2017-01-16T14:35:00.888+01:00")
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Failure(InvalidBagException(
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Failure(InvalidBagException(
       s"No EASY-User-Account in $file"
     ))
   }
@@ -61,7 +61,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |Bagging-Date: 2017-01-16T14:35:00.888+01:00
          |Is-Version-Of: urn:uuid:123456789$uuid
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Failure(InvalidBagException(
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Failure(InvalidBagException(
       s"Invalid UUID: Is-Version-Of: urn:uuid:123456789$uuid"
     ))
   }
@@ -73,7 +73,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
       s"""Bagging-Date: $dateTime
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Success(new BagInfo("user001", dateTime, uuid, "bag-name", None, None))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, uuid, "bag-name", None, None))
   }
   it should "have a version-of" in {
     val bagUuid = UUID.randomUUID()
@@ -85,7 +85,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |Is-Version-Of: $versionOfUuid
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), None))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), None))
   }
   it should "have a base-urn" in {
     val bagUuid = UUID.randomUUID()
@@ -98,19 +98,6 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |${ BagInfo.baseUrnKey }: rabarbera
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = true) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), Some("rabarbera")))
-  }
-  it should "report missing base-urn" in {
-    val bagUuid = UUID.randomUUID()
-    val versionOfUuid = UUID.randomUUID()
-    val bagDir = (testDir / s"$bagUuid" / "bag-name").createDirectories()
-    (bagDir / "bag-info.txt").write(
-      s"""Bagging-Date: 2017-01-16T14:35:00.888+01:00
-         |Is-Version-Of: $versionOfUuid
-         |EASY-User-Account: user001
-         |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = true) shouldBe Failure(InvalidBagException(
-      s"No Base-Urn in $testDir/$bagUuid/bag-name/bag-info.txt"
-    ))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), Some("rabarbera")))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -112,7 +112,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.nbn = urn:nbn:nl:ui:13-z4-f8cm
          |dataverse.id-protocol = urn
-         |dataverse.id-identifier = urn:nbn:nl:ui:13-z4-f8cm
+         |dataverse.id-identifier = z4-f8cm
          |dataverse.id-authority = nbn:nl:ui:13
          |""".stripMargin
     )
@@ -184,7 +184,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |dataverse.nbn = urn:nbn:nl:ui:13-00-3haq
          |dataverse.other-id = https://doi.org/10.12345/foo-bar
          |dataverse.id-protocol = urn
-         |dataverse.id-identifier = urn:nbn:nl:ui:13-00-3haq
+         |dataverse.id-identifier = 00-3haq
          |dataverse.id-authority = nbn:nl:ui:13
          |""".stripMargin
     )

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -145,7 +145,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |identifier.fedora = easy-dataset:162288
          |dataverse.nbn = rabarbera
          |dataverse.id-protocol = urn
-         |dataverse.id-identifier = urn:nbn:nl:ui:13-00-3haq
+         |dataverse.id-identifier = rabarbera
          |dataverse.id-authority = nbn:nl:ui:13
          |""".stripMargin
     )

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -112,7 +112,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.nbn = urn:nbn:nl:ui:13-z4-f8cm
          |dataverse.id-protocol = urn
-         |dataverse.id-identifier = urn:nbn:nl:ui:13-00-3haq
+         |dataverse.id-identifier = urn:nbn:nl:ui:13-z4-f8cm
          |dataverse.id-authority = nbn:nl:ui:13
          |""".stripMargin
     )

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -121,7 +121,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
   it should "use base urn from bag-info.txt" in {
     val bagUUID = UUID.randomUUID()
     val baseUUID = UUID.randomUUID()
-    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), Some("rabarbera"))
+    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), Some("urn:nbn:nl:ui:13-rabarbera"))
     val ddm = <ddm:DDM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <ddm:dcmiMetadata>
                   <dcterms:identifier xsi:type="id-type:DOI">10.5072/dans-2xg-umq8</dcterms:identifier>
@@ -143,7 +143,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |identifier.doi = 10.5072/dans-2xg-umq8
          |identifier.urn = urn:nbn:nl:ui:13-00-3haq
          |identifier.fedora = easy-dataset:162288
-         |dataverse.nbn = rabarbera
+         |dataverse.nbn = urn:nbn:nl:ui:13-rabarbera
          |dataverse.id-protocol = urn
          |dataverse.id-identifier = rabarbera
          |dataverse.id-authority = nbn:nl:ui:13

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -31,10 +31,10 @@ import scala.xml.XML
 
 class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with BagIndexSupport with BagSupport with MockFactory {
 
-  "create" should "not call the bag-index" in {
+  "create" should "call the bag-index for the sequence only" in {
     val uuid = "04e638eb-3af1-44fb-985d-36af12fccb2d"
     val bagDir = File("src/test/resources/bags/01") / uuid / "bag-revision-1"
-    DepositPropertiesFactory(mockedConfig(null), IdType.DOI, BagSource.VAULT)
+    DepositPropertiesFactory(mockedConfig(mockBagIndexRespondsWith("123", 200)), IdType.DOI, BagSource.VAULT)
       .create(
         BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false).unsafeGetOrThrow,
         ddm = XML.loadFile((bagDir / "metadata" / "dataset.xml").toJava),
@@ -107,16 +107,6 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
   it should "use base urn from bag-info.txt" in {
     val bagUUID = UUID.randomUUID()
     val baseUUID = UUID.randomUUID()
-    val bagIndexBody =
-      """<result>
-        |    <bag-info>
-        |        <bag-id>38cb3ff1-d59d-4560-a423-6f761b237a56</bag-id>
-        |        <base-id>38cb3ff1-d59d-4560-a423-6f761b237a56</base-id>
-        |        <created>2016-11-13T00:41:11.000+01:00</created>
-        |        <doi>10.80270/test-28m-zann</doi>
-        |        <urn>urn:nbn:nl:ui:13-z4-f8cm</urn>
-        |    </bag-info>
-        |</result>""".stripMargin
     val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), Some("rabarbera"))
     val ddm = <ddm:DDM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <ddm:dcmiMetadata>
@@ -155,7 +145,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
                 </ddm:dcmiMetadata>
               </ddm:DDM>
 
-    DepositPropertiesFactory(mockedConfig(null), IdType.URN, BagSource.VAULT)
+    DepositPropertiesFactory(mockedConfig(mockBagIndexRespondsWith("123", 200)), IdType.URN, BagSource.VAULT)
       .create(bagInfo, ddm)
       .map(serialize) shouldBe Success(
       s"""state.label = SUBMITTED

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -43,7 +43,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
 
     DepositPropertiesFactory(cfg, IdType.DOI, BagSource.VAULT)
       .create(
-        BagInfo(bagDir, mockBag(bagDir).getMetadata, requireBaseUrnWithVersionOf = false).unsafeGetOrThrow,
+        BagInfo(bagDir, mockBag(bagDir).getMetadata).unsafeGetOrThrow,
         ddm = XML.loadFile((bagDir / "metadata" / "dataset.xml").toJava),
       ).map(serialize) shouldBe Success(
       s"""state.label = SUBMITTED

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/AppConfigSupport.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/AppConfigSupport.scala
@@ -17,12 +17,11 @@ package nl.knaw.dans.easy.bag2deposit.Fixture
 
 import better.files.File
 import nl.knaw.dans.easy.bag2deposit.{ AbrRewriteRule, BagIndex, Configuration }
-import org.scalamock.scalatest.MockFactory
 
 import scala.xml.transform.RuleTransformer
 
-trait AppConfigSupport extends MockFactory {
-  def mockedConfig(bagIndex: BagIndex): Configuration = {
+trait AppConfigSupport extends BagIndexSupport {
+  def testConfig(bagIndex: BagIndex): Configuration = {
     val cfgFile = File("src/main/assembly/dist/cfg")
     new Configuration(
       version = "testVersion",

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/BagIndexSupport.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/BagIndexSupport.scala
@@ -15,30 +15,17 @@
  */
 package nl.knaw.dans.easy.bag2deposit.Fixture
 
-import java.net.URI
-import java.util.UUID
-
 import nl.knaw.dans.easy.bag2deposit.BagIndex
+import org.scalamock.scalatest.MockFactory
 import scalaj.http.HttpResponse
 
-trait BagIndexSupport {
-  /**
-   * Limited to test scenarios where the BagIndex service
-   * always gives the the same response
-   */
-  def mockBagIndexRespondsWith(body: String, code: Int): BagIndex = {
-    new BagIndex(new URI(s"https://does.not.exist.dans.knaw.nl:20120/bags/uuid")) {
-      override def execute(q: String): HttpResponse[String] = {
-        new HttpResponse[String](body, code, headers = Map.empty)
-      }
-    }
-  }
+trait BagIndexSupport extends MockFactory {
 
-  def mockBagIndexThrows(e: Exception): BagIndex = {
-    new BagIndex(new URI(s"https://does.not.exist.dans.knaw.nl:20120/bags/uuid")) {
-      override def execute(q : String): HttpResponse[String] = {
-        throw e
-      }
-    }
+  // mock requires a constructor without parameters
+  class MockBagIndex() extends BagIndex(null)
+
+  // mock the HTTP-request execution to test the rest of the class and/or application
+  def delegatingBagIndex(delegate: BagIndex): BagIndex = new BagIndex(null) {
+    override def execute(q: String): HttpResponse[String] = delegate.execute(q)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/BagIndexSupport.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/BagIndexSupport.scala
@@ -28,7 +28,7 @@ trait BagIndexSupport {
    */
   def mockBagIndexRespondsWith(body: String, code: Int): BagIndex = {
     new BagIndex(new URI(s"https://does.not.exist.dans.knaw.nl:20120/bags/uuid")) {
-      override def execute(uuid: UUID): HttpResponse[String] = {
+      override def execute(q: String): HttpResponse[String] = {
         new HttpResponse[String](body, code, headers = Map.empty)
       }
     }
@@ -36,7 +36,7 @@ trait BagIndexSupport {
 
   def mockBagIndexThrows(e: Exception): BagIndex = {
     new BagIndex(new URI(s"https://does.not.exist.dans.knaw.nl:20120/bags/uuid")) {
-      override def execute(uuid: UUID): HttpResponse[String] = {
+      override def execute(q : String): HttpResponse[String] = {
         throw e
       }
     }


### PR DESCRIPTION
Fixes DD-209: warn if vault bag is part of a sequence

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------
On deasy:
* build/deploy also `easy-fedora-to-bag`, `easy-bag-store` (to create the store archeologie)
  possibly even `easy-bag-index`
* The 9th dataset in deasy (Groningen in Oorlogstijd, interview 01) has both `original` files and other files.
  Fix the EMD by updating it with the web-ui, this action assigns a value to `<dc:identifier eas:scheme="DMO_ID"/>`.
  Create two bag versions:

      easy-fedora-to-bag -d easy-dataset:9 -o /vagrant/shared/split-bags -f AIP original-versioned

* Put the bags in the bag-store.
  The grep result in something like `...<UUID>...Is-Version-Of...<UUID>`.
  Apply the second command first with the last UUID from the grep, then with the first.

      grep Version /vagrant/shared/split-bags/*/bag-info.txt
      easy-bag-store -s test add -u <UUID> /vagrant/shared/split-bags/<UUID>

* update the index of the bag-store:

      sudo service easy-bag-index stop
      easy-bag-index index
      sudo service easy-bag-index start

* [x] move the directories one directory level deeper and: 

      mkdir /vagrant/shared/split-deposits
      easy-convert-bag-to-deposit -t DOI -d /vagrant/shared/split-bags/ -o /vagrant/shared/split-deposits -s VAULT

  The logging shows:

      [2020-11-20 12:44:35,614] WARN  3f0617e7-3b9b-400b-a095-426e33e5402e is part of a sequence
      [2020-11-20 12:44:35,778] INFO  moving bag-parent from /vagrant/shared/split-bags/3f0617e7-3b9b-400b-a095-426e33e5402e to /vagrant/shared/split-deposits/3f0617e7-3b9b-400b-a095-426e33e5402e
      [2020-11-20 12:44:35,780] INFO  OK /vagrant/shared/split-bags/3f0617e7-3b9b-400b-a095-426e33e5402e
      [2020-11-20 12:44:35,821] WARN  b653f4ab-c84c-4f9d-93ac-45855b2f6c86 is part of a sequence
      [2020-11-20 12:44:35,867] INFO  moving bag-parent from /vagrant/shared/split-bags/b653f4ab-c84c-4f9d-93ac-45855b2f6c86 to /vagrant/shared/split-deposits/b653f4ab-c84c-4f9d-93ac-45855b2f6c86
      [2020-11-20 12:44:35,869] INFO  OK /vagrant/shared/split-bags/b653f4ab-c84c-4f9d-93ac-45855b2f6c86

Related pull requests on github
-------------------------------

not applicable
