### PR TITLE
DD-255: doi in baginfo

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
@@ -32,13 +32,14 @@ case class BagIndex(bagIndexUri: URI) {
   def getSeqLength(uuid: UUID): Try[Int] = find(s"/bag-sequence?contains=$uuid")
     .map(_.split("\n").map(_.trim).count(!_.isEmpty))
 
-  def getURN(uuid: UUID): Try[String] = for {
+  def gePIDs(uuid: UUID): Try[(String, String)] = for {
     response <- find(s"/bags/$uuid")
     xml <- parse(response, uuid)
-    nodes = xml \\ "urn"
-    urn = nodes.theSeq.headOption.map(_.text)
+    urn = (xml \\ "urn").theSeq.headOption.map(_.text)
       .getOrElse(throw BagIndexException(s"$uuid: no URN in $response", null))
-  } yield urn
+    doi = (xml \\ "doi").theSeq.headOption.map(_.text)
+      .getOrElse(throw BagIndexException(s"$uuid: no DOI in $response", null))
+  } yield (urn,doi)
 
   private def parse(response: String, uuid: UUID) = Try {
     XML.load(response.inputStream)

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
@@ -26,20 +26,20 @@ import scala.util.{ Failure, Try }
 import scala.xml.XML
 
 case class BagIndexException(msg: String, cause: Throwable) extends IOException(msg, cause)
-
+case class BasePids(urn: String, doi: String)
 case class BagIndex(bagIndexUri: URI) {
 
   def getSeqLength(uuid: UUID): Try[Int] = find(s"/bag-sequence?contains=$uuid")
     .map(_.split("\n").map(_.trim).count(!_.isEmpty))
 
-  def gePIDs(uuid: UUID): Try[(String, String)] = for {
+  def gePIDs(uuid: UUID): Try[BasePids] = for {
     response <- find(s"/bags/$uuid")
     xml <- parse(response, uuid)
     urn = (xml \\ "urn").theSeq.headOption.map(_.text)
       .getOrElse(throw BagIndexException(s"$uuid: no URN in $response", null))
     doi = (xml \\ "doi").theSeq.headOption.map(_.text)
       .getOrElse(throw BagIndexException(s"$uuid: no DOI in $response", null))
-  } yield (urn,doi)
+  } yield BasePids(urn, doi)
 
   private def parse(response: String, uuid: UUID) = Try {
     XML.load(response.inputStream)

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
@@ -26,10 +26,12 @@ import org.apache.commons.configuration.ConfigurationException
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Try }
 
-case class BagInfo(userId: String, created: String, uuid: UUID, bagName: String, versionOf: Option[UUID], baseUrn: Option[String] = None)
+case class BagInfo(userId: String, created: String, uuid: UUID, bagName: String, versionOf: Option[UUID], baseUrn: Option[String] = None, baseDoi: Option[String] = None)
 
 object BagInfo {
+  // these values should match easy-fedora-to-bag
   val baseUrnKey = "Base-Urn"
+  val baseDoiKey = "Base-DOI"
 
   def apply(bagDir: File, bagInfo: Metadata): Try[BagInfo] = Try {
     def getMaybe(key: String) = Option(bagInfo.get(key))

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
@@ -26,7 +26,7 @@ import org.apache.commons.configuration.ConfigurationException
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Try }
 
-case class BagInfo(userId: String, created: String, uuid: UUID, bagName: String, versionOf: Option[UUID], baseUrn: Option[String] = None, baseDoi: Option[String] = None)
+case class BagInfo(userId: String, created: String, uuid: UUID, bagName: String, versionOf: Option[UUID], basePids: Option[BasePids] = None)
 
 object BagInfo {
   // these values should match easy-fedora-to-bag
@@ -42,7 +42,11 @@ object BagInfo {
     def getMandatory(key: String) = getMaybe(key).getOrElse(throw notFound(key))
 
     val maybeVersionOf = getMaybe(DansV0Bag.IS_VERSION_OF_KEY).map(uuidFromVersionOf)
-    val maybeBaseUrn = getMaybe(baseUrnKey)
+    val basePids = (getMaybe(baseUrnKey), getMaybe(baseDoiKey)) match {
+      case (None, None) => None
+      case (Some(urn), Some(doi)) => Some(BasePids(urn, doi))
+      case _ => throw new Exception("")
+    }
 
     new BagInfo(
       userId = getMandatory(DansV0Bag.EASY_USER_ACCOUNT_KEY),
@@ -50,7 +54,7 @@ object BagInfo {
       uuid = uuidFromFile(bagDir.parent),
       bagName = bagDir.name,
       versionOf = maybeVersionOf,
-      baseUrn = maybeBaseUrn,
+      basePids = basePids,
     )
   }.recoverWith { case e: ConfigurationException =>
     Failure(InvalidBagException(e.getMessage))

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.bag2deposit
 
-import java.util.UUID
-
 import nl.knaw.dans.easy.bag2deposit.BagSource.{ BagSource, FEDORA, VAULT, submittedStateDescription }
 import nl.knaw.dans.easy.bag2deposit.IdType._
 import nl.knaw.dans.lib.error.TryExtensions
@@ -27,6 +25,7 @@ import scala.util.Try
 import scala.xml.{ Node, NodeSeq }
 
 case class DepositPropertiesFactory(configuration: Configuration, idType: IdType, bagSource: BagSource) extends DebugEnhancedLogging {
+
   def create(bagInfo: BagInfo, ddm: Node): Try[PropertiesConfiguration] = Try {
     val ddmIds: NodeSeq = ddm \ "dcmiMetadata" \ "identifier"
 
@@ -42,9 +41,14 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
       .getOrElse(throw InvalidBagException("no fedoraID"))
       .text
 
-    lazy val (baseUrnFromBagIndex, baseDoiFromBagIndex) = bagInfo.versionOf.map(
-      configuration.bagIndex.gePIDs(_).unsafeGetOrThrow
-    ).getOrElse((urn, doi))
+    val basePids: BasePids = bagInfo.versionOf.map { uuid =>
+      bagSource match {
+        case VAULT => configuration.bagIndex.gePIDs(uuid).unsafeGetOrThrow
+        case FEDORA => bagInfo.basePids.getOrElse(throw InvalidBagException(
+          s"bag-info.txt should have the ${ BagInfo.baseUrnKey } and ${ BagInfo.baseDoiKey } of ${ bagInfo.versionOf }")
+        )
+      }
+    }.getOrElse(BasePids(urn, doi))
 
     def checkSequence(): Unit = {
       val seqLength = configuration.bagIndex
@@ -73,11 +77,9 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("bag-store.bag-id", bagInfo.uuid)
           addProperty("dataverse.sword-token", bagInfo.versionOf.getOrElse(bagInfo.uuid))
           addProperty("dataverse.bag-id", "urn:uuid:" + bagInfo.uuid)
-          addProperty("dataverse.nbn", baseUrnFromBagIndex)
+          addProperty("dataverse.nbn", basePids.urn)
         case FEDORA =>
-          if (bagInfo.versionOf.isDefined && bagInfo.baseUrn.isEmpty)
-            throw InvalidBagException(s"bag-info.txt should have the ${ BagInfo.baseUrnKey } of ${ bagInfo.versionOf }")
-          addProperty("dataverse.nbn", bagInfo.baseUrn.getOrElse(urn))
+          addProperty("dataverse.nbn", basePids.urn)
         case _ =>
       }
       if (!configuration.dansDoiPrefixes.contains(doi.replaceAll("/.*", "/")))
@@ -85,10 +87,10 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
       addProperty("dataverse.id-protocol", idType.toString.toLowerCase)
       idType match {
         case URN =>
-          addProperty("dataverse.id-identifier", bagInfo.baseUrn.getOrElse(baseUrnFromBagIndex).replace("urn:nbn:nl:ui:13-", ""))
+          addProperty("dataverse.id-identifier", basePids.urn.replace("urn:nbn:nl:ui:13-", ""))
           addProperty("dataverse.id-authority", "nbn:nl:ui:13")
         case DOI =>
-          addProperty("dataverse.id-identifier", bagInfo.baseDoi.getOrElse(baseDoiFromBagIndex).replaceAll(".*/", ""))
+          addProperty("dataverse.id-identifier", basePids.doi.replaceAll(".*/", ""))
           addProperty("dataverse.id-authority", configuration.dataverseIdAutority)
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/EasyConvertBagToDespositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/EasyConvertBagToDespositApp.scala
@@ -44,6 +44,7 @@ class EasyConvertBagToDespositApp(configuration: Configuration) extends DebugEnh
     val bagInfoKeysToRemove = Seq(
       DansV0Bag.EASY_USER_ACCOUNT_KEY,
       BagInfo.baseUrnKey,
+      BagInfo.baseDoiKey,
     )
     for {
       bagDir <- getBagDir(bagParentDir)

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -66,7 +66,7 @@ class AppSpec extends AnyFlatSpec with Matchers with AppConfigSupport with FileS
     (delegate.execute(_: String)) expects s"/bag-sequence?contains=$noBaseBagUUID" returning
       new HttpResponse[String]("123", 200, Map.empty)
     (delegate.execute(_: String)) expects s"/bags/4722d09d-e431-4899-904c-0733cd773034" returning
-      new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn></bag-info></result>", 200, Map.empty)
+      new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn><doi>10.5072/dans-2xg-umq8</doi></bag-info></result>", 200, Map.empty)
     val appConfig = testConfig(delegatingBagIndex(delegate))
 
     new EasyConvertBagToDespositApp(appConfig).addPropsToBags(

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
@@ -56,7 +56,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     (delegate.execute(_: String)) expects s"/bags/$uuid" returning
       new HttpResponse[String]("", 404, Map.empty)
     delegatingBagIndex(delegate)
-      .getURN(uuid) shouldBe Failure(InvalidBagException(s"/bags/$uuid returned not found in bag-index"))
+      .gePIDs(uuid) shouldBe Failure(InvalidBagException(s"/bags/$uuid returned not found in bag-index"))
   }
 
   it should "return URN" in {
@@ -77,7 +77,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
         Map.empty,
       )
     delegatingBagIndex(delegate)
-      .getURN(uuid) shouldBe Success("urn:nbn:nl:ui:13-z4-f8cm")
+      .gePIDs(uuid) shouldBe Success(("urn:nbn:nl:ui:13-z4-f8cm","10.80270/test-28m-zann"))
   }
 
   it should "report missing URN" in {
@@ -86,7 +86,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     (delegate.execute(_: String)) expects s"/bags/$uuid" returning
       new HttpResponse[String]("<x/>", 200, Map.empty)
     delegatingBagIndex(delegate)
-      .getURN(uuid) shouldBe Failure(BagIndexException(s"$uuid: no URN in <x/>", null))
+      .gePIDs(uuid) shouldBe Failure(BagIndexException(s"$uuid: no URN in <x/>", null))
   }
 
   it should "report invalid XML" in {
@@ -95,7 +95,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     (delegate.execute(_: String)) expects s"/bags/$uuid" returning
       new HttpResponse[String]("{}", 200, Map.empty)
     delegatingBagIndex(delegate)
-      .getURN(uuid) should matchPattern {
+      .gePIDs(uuid) should matchPattern {
       case Failure(BagIndexException(msg, _)) if msg == s"$uuid: Content is not allowed in prolog. RESPONSE: {}" =>
     }
   }
@@ -106,7 +106,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     (delegate.execute(_: String)) expects s"/bags/$uuid" throwing new IOException("mocked")
 
     delegatingBagIndex(delegate)
-      .getURN(uuid) should matchPattern {
+      .gePIDs(uuid) should matchPattern {
       case Failure(BagIndexException(msg, _)) if msg == s"/bags/$uuid mocked" =>
     }
   }
@@ -117,6 +117,6 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
     (delegate.execute(_: String)) expects s"/bags/$uuid" returning
       new HttpResponse[String]("", 300, Map.empty)
     delegatingBagIndex(delegate)
-      .getURN(uuid) shouldBe Failure(BagIndexException(s"Not expected response code from bag-index. /bags/$uuid, response: 300 - ", null))
+      .gePIDs(uuid) shouldBe Failure(BagIndexException(s"Not expected response code from bag-index. /bags/$uuid, response: 300 - ", null))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagIndexSpec.scala
@@ -77,7 +77,7 @@ class BagIndexSpec extends AnyFlatSpec with Matchers with BagIndexSupport {
         Map.empty,
       )
     delegatingBagIndex(delegate)
-      .gePIDs(uuid) shouldBe Success(("urn:nbn:nl:ui:13-z4-f8cm","10.80270/test-28m-zann"))
+      .gePIDs(uuid) shouldBe Success(BasePids("urn:nbn:nl:ui:13-z4-f8cm", "10.80270/test-28m-zann"))
   }
 
   it should "report missing URN" in {

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
@@ -96,8 +96,9 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
       s"""Bagging-Date: $dateTime
          |Is-Version-Of: $versionOfUuid
          |${ BagInfo.baseUrnKey }: rabarbera
+         |${ BagInfo.baseDoiKey }: lalala
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), Some("rabarbera")))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), Some(BasePids("rabarbera", "lalala"))))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -121,7 +121,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
   it should "use base urn from bag-info.txt" in {
     val bagUUID = UUID.randomUUID()
     val baseUUID = UUID.randomUUID()
-    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), Some("urn:nbn:nl:ui:13-rabarbera"))
+    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), baseUrn = Some("urn:nbn:nl:ui:13-rabarbera"))
     val ddm = <ddm:DDM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <ddm:dcmiMetadata>
                   <dcterms:identifier xsi:type="id-type:DOI">10.5072/dans-2xg-umq8</dcterms:identifier>

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -121,7 +121,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
   it should "use base urn from bag-info.txt" in {
     val bagUUID = UUID.randomUUID()
     val baseUUID = UUID.randomUUID()
-    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), baseUrn = Some("urn:nbn:nl:ui:13-rabarbera"))
+    val bagInfo = BagInfo(userId = "user001", created = "2017-01-16T14:35:00.888+01:00", uuid = bagUUID, bagName = "bag-name", versionOf = Some(baseUUID), basePids = Some(BasePids("urn:nbn:nl:ui:13-rabarbera", "testDoi")))
     val ddm = <ddm:DDM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <ddm:dcmiMetadata>
                   <dcterms:identifier xsi:type="id-type:DOI">10.5072/dans-2xg-umq8</dcterms:identifier>


### PR DESCRIPTION
Fixes DD-255: doi in baginfo

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

on deasy:
```
rm -rf /vagrant/shared/split*
easy-fedora-to-bag -d easy-dataset:9 -o /vagrant/shared/split-bags -f SIP original-versioned
mkdir /vagrant/shared/split-deposits
easy-convert-bag-to-deposit -t DOI -d /vagrant/shared/split-bags/ -o /vagrant/shared/split-deposits -s FEDORA
cat easy-convert-bag-to-deposit.log
```
resulting `bag-info.txt` and `deposit.properties` files: [Archive.zip](https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/files/5602384/Archive.zip)



Related pull requests on github
-------------------------------

https://github.com/DANS-KNAW/easy-fedora-to-bag/pull/38