### PR TITLE
DD-296: step 2 - log checklist of report numbers

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/bag2deposit/ddm/DdmTransformer.scala
+++ b/src/main/scala/nl/knaw/dans/easy/bag2deposit/ddm/DdmTransformer.scala
@@ -25,7 +25,7 @@ import scala.xml.{ Node, NodeSeq }
 
 case class DdmTransformer(cfgDir: File) extends DebugEnhancedLogging {
 
-  private val reportRewriteRule = ReportRewriteRule(cfgDir)
+  val reportRewriteRule = ReportRewriteRule(cfgDir)
   private val profileRuleTransformer = new RuleTransformer(reportRewriteRule)
   private val dcmiMetadataRuleTransformer = new RuleTransformer(
     reportRewriteRule,

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/RewriteSpec.scala
@@ -123,7 +123,8 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         </ddm:dcmiMetadata>
     )
 
-    new EasyConvertBagToDepositApp(cfg.copy(version = "x.y.z")).formatDiff(ddmIn, expectedDDM) shouldBe Some(
+    val app = new EasyConvertBagToDepositApp(cfg.copy(version = "x.y.z"))
+    app.formatDiff(ddmIn, expectedDDM) shouldBe Some(
       """===== only in old DDM
         |
         |<dc:title>Rapport 456</dc:title>
@@ -154,8 +155,11 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         |""".stripMargin
     )
 
+    // a few steps of EasyConvertBagToDepositApp.addPropsToBags
     cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe
       Success(normalized(expectedDDM))
+    app.registerMatchedReports("easy-dataset:123", expectedDDM \\ "reportNumber")
+    app.logMatchedReports() // once for all datasets
 
     assume(schemaIsAvailable)
     validate(expectedDDM) shouldBe Success(())

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/RewriteSpec.scala
@@ -156,9 +156,10 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
     )
 
     // a few steps of EasyConvertBagToDepositApp.addPropsToBags
-    cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe
+    val datasetId = "easy-dataset:123"
+    cfg.ddmTransformer.transform(ddmIn, datasetId).map(normalized) shouldBe
       Success(normalized(expectedDDM))
-    app.registerMatchedReports("easy-dataset:123", expectedDDM \\ "reportNumber")
+    app.registerMatchedReports(datasetId, expectedDDM \\ "reportNumber")
     app.logMatchedReports() // once for all datasets
 
     assume(schemaIsAvailable)
@@ -175,7 +176,7 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         </ddm:dcmiMetadata>
     )
 
-    cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe Success(normalized(ddmIn))
+    cfg.ddmTransformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe Success(normalized(ddmIn))
     // TODO manually check logging of briefrapport
   }
 
@@ -203,7 +204,7 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         </ddm:dcmiMetadata>
     )
 
-    cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe
+    cfg.ddmTransformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe
       Success(normalized(expectedDdm))
   }
 
@@ -219,7 +220,7 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         </ddm:dcmiMetadata>
     )
 
-    cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe
+    cfg.ddmTransformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe
       Failure(InvalidBagException("rabarbera not found in ABR-period.csv; barbapappa not found in ABR-complex.csv"))
   }
 
@@ -259,7 +260,7 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers {
         </ddm:dcmiMetadata>
     )
     // TODO these titles don't show up in target/test/TitlesSpec/matches-per-rce.txt
-    cfg.ddmTransformer.transform(ddmIn).map(normalized) shouldBe
+    cfg.ddmTransformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe
       Success(normalized(expectedDdm))
   }
 


### PR DESCRIPTION
Fixes DD-296: step 2 - log checklist of report numbers

When applied it will
--------------------
* Produce a checklist on the fly like `matches-per-rce.txt` as produced by `TitleSpec`
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

The logging should look like

per dataset:

```
INFO  BagInfo(user001,2016-06-07,04e638eb-3af1-44fb-985d-36af12fccb2d,bag-revision-1,None,None)
INFO  potential report number: Archeologische Berichten Nijmegen – Briefrapport 21
INFO  OK easy-dataset:987 04e638eb-3af1-44fb-985d-36af12fccb2d/04e638eb-3af1-44fb-985d-36af12fccb2d
```

at the end of the batch:

```
...
INFO  Apeldoorn, Rapport Gemeente

INFO  Rapport
	easy-dataset:123	Rapport 456
	easy-dataset:321	Rapport 123
...
INFO  Transect Rapport
	easy-dataset:789	Transect-rapport 2859
...
```



Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
