### PR TITLE
DD-329: dataverse.bag-id MUST always be set

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -76,16 +76,18 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("bag-store.bag-name", bagInfo.bagName)
           addProperty("bag-store.bag-id", bagInfo.uuid)
           addProperty("dataverse.sword-token", bagInfo.versionOf.getOrElse(bagInfo.uuid))
-          addProperty("dataverse.bag-id", "urn:uuid:" + bagInfo.uuid)
           addProperty("dataverse.nbn", basePids.urn)
         case FEDORA =>
           addProperty("dataverse.nbn", basePids.urn)
         case _ =>
       }
-      if (!configuration.dansDoiPrefixes.contains(doi.replaceAll("/.*", "/")))
+      addProperty("dataverse.bag-id", "urn:uuid:" + bagInfo.uuid)
+      if (!configuration.dansDoiPrefixes.contains(doi.replaceAll("/.*", "/"))) {
+        // not DANS hence other than dataverse.id-identifier
         addProperty("dataverse.other-id", "https://doi.org/" + doi)
+      }
       addProperty("dataverse.id-protocol", idType.toString.toLowerCase)
-      idType match {
+      idType match { // URN/DOI from command line
         case URN =>
           addProperty("dataverse.id-identifier", basePids.urn.replace("urn:nbn:nl:ui:13-", ""))
           addProperty("dataverse.id-authority", "nbn:nl:ui:13")

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/FactorySpec.scala
@@ -57,8 +57,8 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |bag-store.bag-name = bag-revision-1
          |bag-store.bag-id = $uuid
          |dataverse.sword-token = $uuid
-         |dataverse.bag-id = urn:uuid:$uuid
          |dataverse.nbn = urn:nbn:nl:ui:13-00-3haq
+         |dataverse.bag-id = urn:uuid:$uuid
          |dataverse.id-protocol = doi
          |dataverse.id-identifier = dans-2xg-umq8
          |dataverse.id-authority = 10.80270
@@ -109,8 +109,8 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |bag-store.bag-name = bag-name
          |bag-store.bag-id = $bagUUID
          |dataverse.sword-token = $baseUUID
-         |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.nbn = urn:nbn:nl:ui:13-z4-f8cm
+         |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.id-protocol = urn
          |dataverse.id-identifier = z4-f8cm
          |dataverse.id-authority = nbn:nl:ui:13
@@ -144,6 +144,7 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |identifier.urn = urn:nbn:nl:ui:13-00-3haq
          |identifier.fedora = easy-dataset:162288
          |dataverse.nbn = urn:nbn:nl:ui:13-rabarbera
+         |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.id-protocol = urn
          |dataverse.id-identifier = rabarbera
          |dataverse.id-authority = nbn:nl:ui:13
@@ -180,8 +181,8 @@ class FactorySpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |bag-store.bag-name = bag-name
          |bag-store.bag-id = $bagUUID
          |dataverse.sword-token = $bagUUID
-         |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.nbn = urn:nbn:nl:ui:13-00-3haq
+         |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.other-id = https://doi.org/10.12345/foo-bar
          |dataverse.id-protocol = urn
          |dataverse.id-identifier = 00-3haq


### PR DESCRIPTION
Fixes DD-329: dataverse.bag-id MUST always be set

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
