### PR TITLE
NO JIRA. Upgraded parent pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.1</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>


### PR DESCRIPTION
When applied it will
--------------------
* Upgrade the parent pom, so that Java 8 is no longer an RPM dependency. This is necessary to be able to install it on a Data Station without accidentally installing Java 8 which is incompatible with Dataverse.



Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
