### PR TITLE
NO JIRA. Fixed problems with URI path.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagIndex.scala
@@ -29,11 +29,11 @@ case class BagIndexException(msg: String, cause: Throwable) extends IOException(
 case class BasePids(urn: String, doi: String)
 case class BagIndex(bagIndexUri: URI) {
 
-  def getSeqLength(uuid: UUID): Try[Int] = find(s"/bag-sequence?contains=$uuid")
+  def getSeqLength(uuid: UUID): Try[Int] = find(s"bag-sequence?contains=$uuid")
     .map(_.split("\n").map(_.trim).count(!_.isEmpty))
 
   def gePIDs(uuid: UUID): Try[BasePids] = for {
-    response <- find(s"/bags/$uuid")
+    response <- find(s"bags/$uuid")
     xml <- parse(response, uuid)
     urn = (xml \\ "urn").theSeq.headOption.map(_.text)
       .getOrElse(throw BagIndexException(s"$uuid: no URN in $response", null))


### PR DESCRIPTION
NO JIRA.

When applied it will
--------------------
* path part of the request URL for the bag-index is constructed correctly. 

Try the following scratch file to see what this issue was:
```scala
import java.net.URI

val indexUri = new URI("https://darkarchive.dans.knaw.nl/bag-index/")
indexUri.resolve("/bags/1234") // https://darkarchive.dans.knaw.nl/bags/1234
indexUri.resolve("bags/1234") // https://darkarchive.dans.knaw.nl/bag-index/bags/1234
```



Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
