### PR TITLE
DD-394:  multiple archis-nrs + RKLO

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/AbrRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/AbrRewriteRule.scala
@@ -25,19 +25,15 @@ import scala.xml.transform.RewriteRule
 import scala.xml.{ Elem, Node }
 
 case class AbrRewriteRule(oldLabel: String, map: Map[String, Elem]) extends RewriteRule with DebugEnhancedLogging {
-  private def getAbrCode(value: String): String = {
-    val matchBetweenBrackets: Regex = raw"\((.*)\)".r
-    matchBetweenBrackets.findFirstMatchIn(value) match {
-      case Some(m) => m.group(1)
-      case None => value
-    }
-  }
-
   override def transform(node: Node): Seq[Node] = {
     if (!isAbr(node)) node
     else {
-      val key = getAbrCode(node.text)
-      map.getOrElse(key, <notImplemented>{ s"$oldLabel $key not found" }</notImplemented>)
+      val value = node.text
+      // extract last expression between brackets
+      val key = value.trim.replaceAll(".*[(]","").replace(")","").trim
+      if (key.isEmpty)
+        <notImplemented>{ value }</notImplemented>
+      else map.getOrElse(key, <notImplemented>{ s"$oldLabel $key not found" }</notImplemented>)
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DdmTransformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DdmTransformer.scala
@@ -28,22 +28,24 @@ import scala.xml.{ Elem, Node, NodeSeq }
 class DdmTransformer(cfgDir: File, collectionsMap: => Map[String, Elem] = Map.empty) extends DebugEnhancedLogging {
 
   val reportRewriteRule: ReportRewriteRule = ReportRewriteRule(cfgDir)
-  private val splitNrRewriteRule = SplitNrRewriteRule()
   private val acquisitionRewriteRule: AcquisitionRewriteRule = AcquisitionRewriteRule(cfgDir)
+  private val languageRewriteRule = LanguageRewriteRule(cfgDir / "languages.csv")
   private val profileTitleRuleTransformer = new RuleTransformer(
     acquisitionRewriteRule,
     reportRewriteRule,
   )
   private val archaeologyRuleTransformer = new RuleTransformer(
-    splitNrRewriteRule,
+    SplitNrRewriteRule,
     acquisitionRewriteRule,
     reportRewriteRule,
     AbrRewriteRule.temporalRewriteRule(cfgDir),
     AbrRewriteRule.subjectRewriteRule(cfgDir),
-    LanguageRewriteRule(cfgDir / "languages.csv"),
+    DropEmptyRewriteRule,
+    languageRewriteRule,
   )
   private val standardRuleTransformer = new RuleTransformer(
-    LanguageRewriteRule(cfgDir / "languages.csv"),
+    DropEmptyRewriteRule,
+    languageRewriteRule,
   )
 
   private case class ArchaeologyRewriteRule(additionalElements: NodeSeq) extends RewriteRule {

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DdmTransformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DdmTransformer.scala
@@ -28,12 +28,14 @@ import scala.xml.{ Elem, Node, NodeSeq }
 class DdmTransformer(cfgDir: File, collectionsMap: => Map[String, Elem] = Map.empty) extends DebugEnhancedLogging {
 
   val reportRewriteRule: ReportRewriteRule = ReportRewriteRule(cfgDir)
+  private val splitNrRewriteRule = SplitNrRewriteRule()
   private val acquisitionRewriteRule: AcquisitionRewriteRule = AcquisitionRewriteRule(cfgDir)
   private val profileTitleRuleTransformer = new RuleTransformer(
     acquisitionRewriteRule,
     reportRewriteRule,
   )
   private val archaeologyRuleTransformer = new RuleTransformer(
+    splitNrRewriteRule,
     acquisitionRewriteRule,
     reportRewriteRule,
     AbrRewriteRule.temporalRewriteRule(cfgDir),

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DropEmptyRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DropEmptyRewriteRule.scala
@@ -15,8 +15,8 @@
  */
 package nl.knaw.dans.easy.bag2deposit.ddm
 
-import scala.xml.Node
 import scala.xml.transform.RewriteRule
+import scala.xml.{ Elem, Node, Text }
 
 object DropEmptyRewriteRule extends RewriteRule {
   private val labels = Seq(
@@ -37,9 +37,13 @@ object DropEmptyRewriteRule extends RewriteRule {
   )
 
   override def transform(node: Node): Seq[Node] = {
-    if (node.text.trim.isEmpty && labels.contains(node.label))
-      Seq.empty
-    else node
+    if (node.text.trim.nonEmpty) node
+    else if (!labels.contains(node.label)) node
+         else {
+           val href = node.attribute("href").toSeq.flatten.text
+           if (href.isEmpty) Seq.empty
+           else node.asInstanceOf[Elem].copy(child = new Text(href))
+         }
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DropEmptyRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/DropEmptyRewriteRule.scala
@@ -15,20 +15,31 @@
  */
 package nl.knaw.dans.easy.bag2deposit.ddm
 
+import scala.xml.Node
 import scala.xml.transform.RewriteRule
-import scala.xml.{ Elem, Node, Text }
 
-object SplitNrRewriteRule extends RewriteRule {
+object DropEmptyRewriteRule extends RewriteRule {
+  private val labels = Seq(
+    "linkedRelation",
+    "conformsTo",
+    "hasFormat",
+    "hasPart",
+    "hasVersion",
+    "isFormatOf",
+    "isPartOf",
+    "isReferencedBy",
+    "isReplacedBy",
+    "isRequiredBy",
+    "isVersionOf",
+    "references",
+    "replaces",
+    "requires",
+  )
 
   override def transform(node: Node): Seq[Node] = {
-    node match {
-      case Elem(_, "identifier", _, _, Text(value)) if value.toLowerCase.matches(".*;.*[(]archis.*") =>
-        val Array(nrs, trailer) = value.split(" *[(]", 2)
-        nrs.split("[,;] *").map(nr =>
-          node.asInstanceOf[Elem].copy(child = new Text(s"$nr ($trailer"))
-        )
-      case _ => node
-    }
+    if (node.text.trim.isEmpty && labels.contains(node.label))
+      Seq.empty
+    else node
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/SplitNrRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/SplitNrRewriteRule.scala
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.bag2deposit.ddm
+
+import scala.xml.transform.RewriteRule
+import scala.xml.{ Elem, Node, Text }
+
+case class SplitNrRewriteRule() extends RewriteRule {
+
+  override def transform(node: Node): Seq[Node] = {
+    node match {
+      case Elem(_, "identifier", _, _, Text(value)) if value.toLowerCase.matches(".*;.*[(]archis.*") =>
+        val Array(nrs, trailer) = value.split(" *[(]", 2)
+        nrs.split("[,;] *").map(nr =>
+          node.asInstanceOf[Elem].copy(child = new Text(s"$nr ($trailer"))
+        )
+      case _ => node
+    }
+  }
+}
+

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/SplitNrRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/SplitNrRewriteRule.scala
@@ -22,6 +22,10 @@ object SplitNrRewriteRule extends RewriteRule {
 
   override def transform(node: Node): Seq[Node] = {
     node match {
+      case Elem(_, "identifier", _, _, Text(value)) if node.attributes.toString.contains("id-type:ARCHIS-") =>
+        value.split("[,;] *").map(nr =>
+          node.asInstanceOf[Elem].copy(child = new Text(nr)
+        ))
       case Elem(_, "identifier", _, _, Text(value)) if value.toLowerCase.matches(".*;.*[(]archis.*") =>
         val Array(nrs, trailer) = value.split(" *[(]", 2)
         nrs.split("[,;] *").map(nr =>

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -370,4 +370,23 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
         </ddm:dcmiMetadata>
       )))
   }
+  it should "drop empty relation" in {
+    val ddmIn = ddm(title = "blabla", audience = "D37000", dcmi =
+        <ddm:dcmiMetadata>
+          <dct:isFormatOf scheme="blabla"></dct:isFormatOf>
+          <ddm:isRequiredBy href="http://does.not.exist.dans.knaw.nl"></ddm:isRequiredBy>
+        </ddm:dcmiMetadata>
+    )
+    val transformer = new DdmTransformer(
+      cfgDir,
+      Map.empty,
+    )
+
+    transformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe
+      Success(normalized(ddm(
+        title = "blabla",
+        audience = "D37000",
+        dcmi = <ddm:dcmiMetadata></ddm:dcmiMetadata>,
+      )))
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -340,4 +340,34 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
       )))
     // content of the <inCollection> element is validated in CollectionsSpec.collectionDatasetIdToInCollection
   }
+  it should "split archis nrs" in {
+    val ddmIn = ddm(title = "blabla", audience = "D37000", dcmi =
+        <ddm:dcmiMetadata>
+          <dct:identifier scheme="blabla">411047; 411049; 411050 (Archis-vondstmeldingsnr.)</dct:identifier>
+          <dct:identifier>52427; 52429; 52431; 52433; 52435; 52437; 52439; 52441; 52462 (RAAP) (Archis waarneming)</dct:identifier>
+        </ddm:dcmiMetadata>
+    )
+    val transformer = new DdmTransformer(
+      cfgDir,
+      Map.empty,
+    )
+
+    transformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe Success(normalized(
+      ddm(title = "blabla", audience = "D37000", dcmi =
+        <ddm:dcmiMetadata>
+          <dct:identifier scheme="blabla">411047 (Archis-vondstmeldingsnr.)</dct:identifier>
+          <dct:identifier scheme="blabla">411049 (Archis-vondstmeldingsnr.)</dct:identifier>
+          <dct:identifier scheme="blabla">411050 (Archis-vondstmeldingsnr.)</dct:identifier>
+          <dct:identifier>52427 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52429 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52431 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52433 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52435 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52437 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52439 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52441 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier>52462 (RAAP) (Archis waarneming)</dct:identifier>
+        </ddm:dcmiMetadata>
+      )))
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -401,7 +401,9 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
       Success(normalized(ddm(
         title = "blabla",
         audience = "D37000",
-        dcmi = <ddm:dcmiMetadata></ddm:dcmiMetadata>,
+        dcmi = <ddm:dcmiMetadata>
+                 <ddm:isRequiredBy href="http://does.not.exist.dans.knaw.nl">http://does.not.exist.dans.knaw.nl</ddm:isRequiredBy>
+               </ddm:dcmiMetadata>,
       )))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -360,18 +360,18 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
     transformer.transform(ddmIn, "easy-dataset:123").map(normalized) shouldBe Success(normalized(
       ddm(title = "blabla", audience = "D37000", dcmi =
         <ddm:dcmiMetadata>
-          <dct:identifier scheme="blabla">411047 (Archis-vondstmeldingsnr.)</dct:identifier>
-          <dct:identifier scheme="blabla">411049 (Archis-vondstmeldingsnr.)</dct:identifier>
-          <dct:identifier scheme="blabla">411050 (Archis-vondstmeldingsnr.)</dct:identifier>
-          <dct:identifier>52427 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52429 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52431 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52433 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52435 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52437 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52439 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52441 (RAAP) (Archis waarneming)</dct:identifier>
-          <dct:identifier>52462 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING" scheme="blabla">411047</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING" scheme="blabla">411049</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING" scheme="blabla">411050</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52427</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52429</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52431</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52433</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52435</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52437</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52439</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52441</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">52462</dct:identifier>
           <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">441832</dct:identifier>
           <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">1234</dct:identifier>
           <dct:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">567</dct:identifier>

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -343,8 +343,13 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
   it should "split archis nrs" in {
     val ddmIn = ddm(title = "blabla", audience = "D37000", dcmi =
         <ddm:dcmiMetadata>
-          <dct:identifier scheme="blabla">411047; 411049; 411050 (Archis-vondstmeldingsnr.)</dct:identifier>
+          <dct:identifier scheme="blabla">411047; 411049; 411050;  (Archis-vondstmeldingsnr.)</dct:identifier>
           <dct:identifier>52427; 52429; 52431; 52433; 52435; 52437; 52439; 52441; 52462 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">441832; 1234</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">567; 89</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING">1011; 1213</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-MONUMENT">1415; 1617</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ONDERZOEK">443456; 789; </dct:identifier>
         </ddm:dcmiMetadata>
     )
     val transformer = new DdmTransformer(
@@ -367,6 +372,16 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
           <dct:identifier>52439 (RAAP) (Archis waarneming)</dct:identifier>
           <dct:identifier>52441 (RAAP) (Archis waarneming)</dct:identifier>
           <dct:identifier>52462 (RAAP) (Archis waarneming)</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">441832</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-WAARNEMING">1234</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">567</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">89</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING">1011</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-VONDSTMELDING">1213</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-MONUMENT">1415</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-MONUMENT">1617</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ONDERZOEK">443456</dct:identifier>
+          <dct:identifier xsi:type="id-type:ARCHIS-ONDERZOEK">789</dct:identifier>
         </ddm:dcmiMetadata>
       )))
   }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -60,7 +60,12 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
             <dc:subject xsi:type="abr:ABRcomplex">EGVW</dc:subject>
             <dcterms:subject xsi:type="abr:ABRcomplex">ELA</dcterms:subject>
             <ddm:subject xml:lang="nl" valueURI="http://www.rnaproject.org/data/39a61516-5ebd-43ad-9cde-98b5089c71ff" subjectScheme="Archeologisch Basis Register" schemeURI="http://www.rnaproject.org">Onbekend (XXX)</ddm:subject>
-        </ddm:dcmiMetadata>
+            <ddm:subject xml:lang="nl"
+                         valueURI="http://www.rnaproject.org/data/54f419f0-d185-4ea5-a188-57e25493a5e0"
+                         subjectScheme="Archeologisch Basis Register"
+                         schemeURI="http://www.rnaproject.org"
+            >Religie - Klooster(complex) (RKLO)</ddm:subject>
+            </ddm:dcmiMetadata>
     )
 
     val expectedDDM = ddm(title = "Rapport 123", audience = "D37000", dcmi =
@@ -98,6 +103,11 @@ class RewriteSpec extends AnyFlatSpec with SchemaSupport with Matchers with DdmS
                          subjectScheme="ABR Complextypen"
                          schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
             >complextype niet te bepalen</ddm:subject>
+            <ddm:subject xml:lang="nl"
+                         valueURI="https://data.cultureelerfgoed.nl/term/id/abr/28e58033-875e-4f90-baa2-7b1c1c147574"
+                         subjectScheme="ABR Complextypen"
+                         schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
+            >klooster</ddm:subject>
         </ddm:dcmiMetadata>
     )
 


### PR DESCRIPTION
Fixes DD-394:  RKLO + multiple archis-nrs

When applied it will
--------------------
* split identifiers that contain multiple archis numbers
* fix ABR mapping for "Religie - Klooster(complex) (RKLO)"
* drop empty relation elements
* swapping out-of-bounds RD coordinates will be fixed in https://github.com/DANS-KNAW/easy-fedora-to-bag/

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
