### PR TITLE
save provenance in a file

### DIFF
--- a/src/test/resources/bags/01/04e638eb-3af1-44fb-985d-36af12fccb2d/bag-revision-1/metadata/dataset.xml
+++ b/src/test/resources/bags/01/04e638eb-3af1-44fb-985d-36af12fccb2d/bag-revision-1/metadata/dataset.xml
@@ -15,6 +15,8 @@ xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.k
     <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
   </ddm:profile>
   <ddm:dcmiMetadata>
+    <dc:title>Example</dc:title>
+    <dc:title>Another title that is not part of another one</dc:title>
     <dcterms:type xsi:type="dcterms:DCMIType">Text</dcterms:type>
     <dcterms:identifier xsi:type="id-type:DOI">10.5072/dans-2xg-umq8</dcterms:identifier>
     <dcterms:identifier xsi:type="id-type:URN">urn:nbn:nl:ui:13-00-3haq</dcterms:identifier>

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.bag2deposit
 
 import better.files.File
-import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.bag.v0.DansV0Bag.EASY_USER_ACCOUNT_KEY
 import nl.knaw.dans.easy.bag2deposit.BagSource._
 import nl.knaw.dans.easy.bag2deposit.Fixture.{ AppConfigSupport, FileSystemSupport }
@@ -28,38 +27,10 @@ import scalaj.http.HttpResponse
 import scala.util.Success
 
 class AppSpec extends AnyFlatSpec with Matchers with AppConfigSupport with FileSystemSupport {
+  private val resourceBags: File = File("src/test/resources/bags/01")
   private val validUUID = "04e638eb-3af1-44fb-985d-36af12fccb2d"
-  private val srcDir = testDir / "exports" / validUUID / "bag-revision-1"
-  private val targetDir = testDir / "ingest-dir" / validUUID / "bag-revision-1"
 
-  "addPropsToBags" should "alter original deposit dir" in {
-    copyBags(Array(File("src/test/resources/bags/01") / validUUID))
-
-    // pre conditions
-    srcDir / ".." / "deposit.properties" shouldNot exist
-    (srcDir / "bag-info.txt").contentAsString should include(EASY_USER_ACCOUNT_KEY)
-    val manifestContent = (srcDir / "tagmanifest-sha1.txt").contentAsString
-
-    val appConfig = testConfig(null)
-    new EasyConvertBagToDepositApp(appConfig).addPropsToBags(
-      (testDir / "exports").children,
-      None,
-      DepositPropertiesFactory(appConfig, URN, FEDORA)
-    ) shouldBe Success("No fatal errors")
-
-    // post conditions
-    (testDir / "exports").children.toList.size shouldBe 1
-    srcDir / ".." / "deposit.properties" should exist // content verified in FactorySpec
-    (srcDir / "bag-info.txt").contentAsString shouldNot include(EASY_USER_ACCOUNT_KEY)
-    (srcDir / "tagmanifest-sha1.txt") should not be manifestContent
-  }
-
-  it should "move only the valid export" in {
-    copyBags(File("src/test/resources/bags/01").children.toArray)
-
-    // pre condition
-    srcDir / ".." / "deposit.properties" shouldNot exist
-
+  "addPropsToBags" should  "move valid exports" in {
     val delegate = mock[MockBagIndex]
     val noBaseBagUUID = "87151a3a-12ed-426a-94f2-97313c7ae1f2"
     (delegate.execute(_: String)) expects s"bag-sequence?contains=$validUUID" returning
@@ -70,25 +41,58 @@ class AppSpec extends AnyFlatSpec with Matchers with AppConfigSupport with FileS
       new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn><doi>10.5072/dans-2xg-umq8</doi></bag-info></result>", 200, Map.empty)
     val appConfig = testConfig(delegatingBagIndex(delegate))
 
+    (resourceBags.children.toArray).foreach { testBag =>
+      testBag.copyTo(
+        (testDir / "exports" / testBag.name).createDirectories()
+      )
+    }
+
+    //////// end of mocking and preparations
+
     new EasyConvertBagToDepositApp(appConfig).addPropsToBags(
       (testDir / "exports").children,
       maybeOutputDir = Some((testDir / "ingest-dir").createDirectories()),
       DepositPropertiesFactory(appConfig, DOI, VAULT)
     ) shouldBe Success("No fatal errors")
 
-    // post condition
-    (targetDir / ".." / "deposit.properties").contentAsString should include("dataverse.id-identifier = dans-2xg-umq8")
-    // other details verified in other test, note that the DOI has no prefix
+    //////// general post conditions
 
     // TODO (manually) intercept logging: the bag names should reflect the errors
     //  no variation in bag-info.txt not found or a property in that file not found
-  }
 
-  private def copyBags(bagsToProcess: Array[File]): Unit = {
-    bagsToProcess.foreach { testBag =>
-      testBag.copyTo(
-        (testDir / "exports" / testBag.name).createDirectories()
-      )
-    }
+    val movedDirs = (testDir / "ingest-dir").children.toList
+    val leftDirs = (testDir / "exports").children.toList
+
+    // only moved dirs changed
+    leftDirs.foreach(dir => dir.isSameContentAs(resourceBags / dir.name) shouldBe true)
+    movedDirs.foreach(dir => dir.isSameContentAs(resourceBags / dir.name) shouldBe false)
+
+    // total number of deposits should not change
+    movedDirs.size + leftDirs.size shouldBe  resourceBags.children.toList.size
+
+    movedDirs.size shouldBe 2 // base-bag-not-found is moved together with the valid bag-revision-1
+    // TODO should addPropsToBags check existence of base-bag in case of versioned bags?
+    //  If so, can the base-bag have been moved to ingest-dir while processing?
+
+    //////// changes made to the valid bag
+
+    val validBag = resourceBags / validUUID / "bag-revision-1"
+    val movedBag = testDir / "ingest-dir" / validUUID / "bag-revision-1"
+
+    // content verified in BagInfoSpec
+    validBag / ".." / "deposit.properties" shouldNot exist
+    movedBag / ".." / "deposit.properties" should exist
+
+    // other content changes verified in DepositPropertiesFactorySpec
+    (validBag / "bag-info.txt").contentAsString should include(EASY_USER_ACCOUNT_KEY)
+    (movedBag / "bag-info.txt").contentAsString shouldNot include(EASY_USER_ACCOUNT_KEY)
+
+    // content of provenance verified in ddm.ProvenanceSpec
+    (validBag / "tagmanifest-sha1.txt").contentAsString shouldNot include("metadata/provenance.xml")
+    (movedBag / "tagmanifest-sha1.txt").contentAsString should include("metadata/provenance.xml")
+
+    // other content changes are verified in ddm.*Spec
+    (validBag / "metadata" / "dataset.xml").contentAsString should include("<dc:title>Example</dc:title>")
+    (movedBag / "metadata" / "dataset.xml").contentAsString shouldNot include("<dc:title>Example</dc:title>")
   }
 }


### PR DESCRIPTION
Fixes EASY-

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

* run AppSpec 
* feed `target/test/AppSpec/ingest-dir/*/bag-revision-1` to `easy-validate-dans-bag`
  before deploying `easy-validate-dans-bag` one of the complaints will be 

     - [2.5] Directory metadata contains files or directories that are not allowed: metadata/provenance.xml 

Related pull requests on github
-------------------------------

deployment depends on
https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/102
which in turn is related to 
https://github.com/DANS-KNAW/dans-bagit-profile/pull/19
