### PR TITLE
DD-451:  xml:lang nl -> nld

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/AbrRewriteRule.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/AbrRewriteRule.scala
@@ -67,7 +67,7 @@ object AbrRewriteRule {
   private def temporalMap(cfgDir: File): Map[String, Elem] = {
     parseCsv(cfgDir / "ABR-period.csv", nrOfHeaderLines, csvFormat)
       .map(record => record.get("old") ->
-        <ddm:temporal xml:lang="nl"
+        <ddm:temporal xml:lang="nld"
            valueURI={ valueUri(record.get("uuid")) }
            subjectScheme={ "ABR Periodes" }
            schemeURI={ "https://data.cultureelerfgoed.nl/term/id/abr/9b688754-1315-484b-9c89-8817e87c1e84" }
@@ -78,7 +78,7 @@ object AbrRewriteRule {
   private def subjectMap(cfgDir: File): Map[String, Elem] = {
     parseCsv(cfgDir / "ABR-complex.csv", nrOfHeaderLines, csvFormat)
       .map(record => record.get("old") ->
-        <ddm:subject xml:lang="nl"
+        <ddm:subject xml:lang="nld"
           valueURI={ valueUri(record.get("uuid")) }
           subjectScheme={ "ABR Complextypen" }
           schemeURI={ "https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0" }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/RewriteSpec.scala
@@ -78,27 +78,27 @@ class RewriteSpec extends AnyFlatSpec with XmlSupport with SchemaSupport with Ma
               subjectScheme="ABR Rapporten"
               reportNo="456"
             >Rapport 456</ddm:reportNumber>
-            <ddm:temporal xml:lang="nl"
+            <ddm:temporal xml:lang="nld"
                           valueURI="https://data.cultureelerfgoed.nl/term/id/abr/330e7fe0-a1f7-43de-b448-d477898f6648"
                           subjectScheme="ABR Periodes"
                           schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/9b688754-1315-484b-9c89-8817e87c1e84"
             >Vroege Middeleeuwen A</ddm:temporal>
-            <ddm:subject xml:lang="nl"
+            <ddm:subject xml:lang="nld"
                          valueURI="https://data.cultureelerfgoed.nl/term/id/abr/6ae3ab19-49ca-44a7-8b65-3a3395014bb9"
                          subjectScheme="ABR Complextypen"
                          schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
             >veenwinning (inclusief zouthoudend veen t.b.v. zoutproductie)</ddm:subject>
-            <ddm:subject xml:lang="nl"
+            <ddm:subject xml:lang="nld"
                          valueURI="https://data.cultureelerfgoed.nl/term/id/abr/f182d72c-2d22-47ae-b799-26dea01e770c"
                          subjectScheme="ABR Complextypen"
                          schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
             >akker / tuin</ddm:subject>
-            <ddm:subject xml:lang="nl"
+            <ddm:subject xml:lang="nld"
                          valueURI="https://data.cultureelerfgoed.nl/term/id/abr/5fbda024-be3e-47ac-a6c8-1c58d2cf5ccc"
                          subjectScheme="ABR Complextypen"
                          schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
             >complextype niet te bepalen</ddm:subject>
-            <ddm:subject xml:lang="nl"
+            <ddm:subject xml:lang="nld"
                          valueURI="https://data.cultureelerfgoed.nl/term/id/abr/28e58033-875e-4f90-baa2-7b1c1c147574"
                          subjectScheme="ABR Complextypen"
                          schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"


### PR DESCRIPTION
Fixes DD-451:  xml:lang nl -> nld

When applied it will
--------------------
* `<ddm:subject xml:lang="nl">` will become `nld` for ABR
* 
* 

Where should the reviewer @DANS-KNAW/easy @DANS-KNAW/dataversedans  start?
------------------------------------------------

Not sure about these mappings in [fedora-to-bag](https://github.com/DANS-KNAW/easy-fedora-to-bag/blob/2a47e60e8a267c00e1863f3e6e72172d4abd2e8f/src/main/scala/nl/knaw/dans/easy/fedoratobag/DDM.scala#L99-L109)
See also line 177, other languages are copied verbatim from EMD

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

replaces #43 
