### PR TITLE
DD-660: report failures not only in logging

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/Command.scala
@@ -17,9 +17,11 @@ package nl.knaw.dans.easy.bag2deposit
 
 import better.files.File
 import better.files.File.root
+import cats.implicits.{ catsStdInstancesForTry, catsSyntaxApplicativeError }
 import nl.knaw.dans.easy.bag2deposit.collections.Collection.getCollectionsMap
 import nl.knaw.dans.easy.bag2deposit.collections.FedoraProvider
 import nl.knaw.dans.easy.bag2deposit.ddm.DdmTransformer
+import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
@@ -65,9 +67,10 @@ object Command extends App with DebugEnhancedLogging {
     userTransformer = new UserTransformer(cfgPath),
     fedoraProvider = fedoraProvider,
     maybePreStagedProvider = if (commandLine.preStaged())
-                          Some(PreStagedProvider(new URI(properties.getString("migration-info.url"))))
+                               Some(PreStagedProvider(new URI(properties.getString("migration-info.url"))))
                              else None
   )
+  trace(configuration.maybePreStagedProvider)
   private val propertiesFactory = DepositPropertiesFactory(
     configuration,
     commandLine.idType(),
@@ -79,4 +82,7 @@ object Command extends App with DebugEnhancedLogging {
       commandLine.outputDir.toOption,
       propertiesFactory
     ).map(msg => println(s"$msg, for details see logging"))
+    .doIfFailure { case e =>
+      println(s"$e; for details see logging")
+    }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
@@ -21,6 +21,7 @@ import org.json4s.native.JsonMethods.parse
 import org.json4s.{ DefaultFormats, Formats }
 import scalaj.http.{ Http, HttpResponse }
 
+import java.io.IOException
 import java.net.URI
 import java.nio.file.{ Path, Paths }
 import scala.util.{ Failure, Success, Try }
@@ -82,11 +83,11 @@ case class PreStagedProvider(migrationInfoUri: URI) {
   private def find(q: String): Try[String] = Try {
     execute(q)
   }.recoverWith {
-    case t: Throwable => Failure(new Exception(s"$q ${ t.getMessage }", t))
+    case t: Throwable => Failure(new IOException(s"dd-migration-info failure with $q CAUSE: $t", t))
   }.map {
     case response if response.code == 404 => "[]" // an empty list
     case response if response.code == 200 => response.body
-    case response => throw new Exception(
+    case response => throw new IOException(
       s"Not expected response code from dd-migration-info. $q, response: ${ response.code } - ${ response.body }",
       null,
     )


### PR DESCRIPTION
Fixes DD-660: report failures not only in logging

When applied it will
--------------------
* report a fatal error on standard output
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

See https://drivenbydata.atlassian.net/browse/DD-660

Response of the application for this specific scenario:

    java.io.IOException: dd-migration-info failure with /datasets/:persistentId/seq/1/basic-file-metas?persistentId=doi:10.17026/dans-x8j-87x3 CAUSE: java.net.ConnectException: Connection refused (Connection refused); for details see logging

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
