### PR TITLE
DD-709: Give dataverse.other-id a prefix for PAN

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactory.scala
@@ -86,7 +86,7 @@ case class DepositPropertiesFactory(configuration: Configuration, idType: IdType
           addProperty("dataverse.sword-token", bagInfo.versionOf.getOrElse(bagInfo.uuid))
           addProperty("dataverse.nbn", basePids.urn)
           formatOfPanId.foreach(node =>
-            addProperty("dataverse.other-id", node.text)
+            addProperty("dataverse.other-id", node.text.replace("-",":"))
           )
         case FEDORA =>
           addProperty("dataverse.nbn", basePids.urn)

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactorySpec.scala
@@ -112,7 +112,7 @@ class DepositPropertiesFactorySpec extends AnyFlatSpec with Matchers with AppCon
          |bag-store.bag-id = $bagUUID
          |dataverse.sword-token = $baseUUID
          |dataverse.nbn = urn:nbn:nl:ui:13-z4-f8cm
-         |dataverse.other-id = PAN-00019180
+         |dataverse.other-id = PAN:00019180
          |dataverse.bag-id = urn:uuid:$bagUUID
          |dataverse.id-protocol = urn
          |dataverse.id-identifier = z4-f8cm


### PR DESCRIPTION
Fixes DD-709

When applied it will
--------------------
* Give dataverse.other-id a prefix for PAN
 

Where should the reviewer @DANS-KNAW/easy start?


