### PR TITLE
No JIRA. Always write provenance.xml and fail if easy-migration folder cannot be successfully filled

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
@@ -99,7 +99,7 @@ case class PreStagedProvider(migrationInfoUri: URI) {
   def execute(q: String): HttpResponse[String] = {
     trace(migrationInfoUri, q)
     Http(migrationInfoUri.resolve(q).toString)
-      .header("Accept", "text/json")
+      .header("Accept", "application/json")
       .asString
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/Provenance.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/Provenance.scala
@@ -31,12 +31,10 @@ class Provenance(app: String, version: String) extends DebugEnhancedLogging {
    *                the values are an empty list or the content for <prov:migration>
    * @return
    */
-  def collectChangesInXmls(changes: Map[String, Seq[Node]]): Option[Elem] = {
+  def collectChangesInXmls(changes: Map[String, Seq[Node]]): Elem = {
     trace(this.getClass)
     val filtered = changes.filter(_._2.nonEmpty)
-    if (filtered.isEmpty) None
-    else Some(
-      <prov:provenance xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+     <prov:provenance xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
         xmlns:prov="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -52,7 +50,7 @@ class Provenance(app: String, version: String) extends DebugEnhancedLogging {
         }}
         </prov:migration>
       </prov:provenance>
-    )
+
   }
 }
 object Provenance {

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
@@ -99,7 +99,7 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
         "http://easy.dans.knaw.nl/schemas/md/ddm/" ->
           Provenance.compare((ddmIn \ "dcmiMetadata").head, (ddmOut \ "dcmiMetadata").head),
       ))
-      .map(normalized) shouldBe Some(normalized(
+      .map(normalized) shouldBe List(normalized(
       <prov:provenance xsi:schemaLocation="
         http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
         http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd
@@ -146,7 +146,7 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
     val amdOut = transformer.transform(amdIn).getOrElse(fail("could not transform"))
     new Provenance("EasyConvertBagToDepositApp", "1.0.5").collectChangesInXmls(Map(
       "http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" -> compare(amdIn, amdOut),
-    )).map(normalized) shouldBe Some(normalized(
+    )).map(normalized) shouldBe List(normalized(
       <prov:provenance xsi:schemaLocation="
         http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
         http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd


### PR DESCRIPTION
NO JIRA

When applied it will
--------------------
* Always write `provenance.xml`, even if no changes are there to be recorded.
* Make sure Failures from `copyMigrationFiles` are not ignored.

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

