### PR TITLE
DD-723 missing pre-staged files

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
@@ -53,6 +53,9 @@ object BagInfo {
       case _ => throw new Exception("")
     }
 
+    // workaround when no seqNr was provided by easy-fedora-to-bag (works if a dataset produced at most two bags)
+    val defaultSeqNr = maybeVersionOf.map(_ => "2").getOrElse("1")
+    val maybeSeqNr = Option(bagInfo.get(BagFacade.BAG_SEQUENCE_NUMBER)).flatMap(_.asScala.headOption)
     new BagInfo(
       userId = getMandatory(BagFacade.EASY_USER_ACCOUNT_KEY),
       created = getMandatory("Bagging-Date"),
@@ -60,7 +63,7 @@ object BagInfo {
       bagName = bagDir.name,
       versionOf = maybeVersionOf,
       basePids = basePids,
-      bagSeqNr = Option(bagInfo.get(BagFacade.BAG_SEQUENCE_NUMBER)).flatMap(_.asScala.headOption).getOrElse("1").toInt,
+      bagSeqNr = maybeSeqNr.getOrElse(defaultSeqNr).toInt,
     )
   }.recoverWith { case e: ConfigurationException =>
     Failure(InvalidBagException(e.getMessage))

--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/PreStaged.scala
@@ -97,8 +97,9 @@ case class PreStagedProvider(migrationInfoUri: URI) {
   }
 
   def execute(q: String): HttpResponse[String] = {
-    trace(migrationInfoUri, q)
-    Http(migrationInfoUri.resolve(q).toString)
+    val request = migrationInfoUri.resolve(q).toString
+    trace(request)
+    Http(request)
       .header("Accept", "application/json")
       .asString
   }

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -42,7 +42,8 @@ class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSu
     (delegate.execute(_: String)) expects s"bags/4722d09d-e431-4899-904c-0733cd773034" returning
       new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn><doi>10.5072/dans-2xg-umq8</doi></bag-info></result>", 200, Map.empty)
     val appConfig = testConfig(delegatingBagIndex(delegate), None)
-    (appConfig.maybePreStagedProvider.get.get(_: String, _: Int)) expects(*, 1) returning Success(Seq.empty) twice
+    (appConfig.maybePreStagedProvider.get.get(_: String, _: Int)) expects(*, 1) returning Success(Seq.empty)
+    (appConfig.maybePreStagedProvider.get.get(_: String, _: Int)) expects(*, 2) returning Success(Seq.empty)
 
     resourceBags.copyTo(testDir / "exports")
 
@@ -376,7 +377,7 @@ class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSu
     (delegate.execute(_: String)) expects s"bags/4722d09d-e431-4899-904c-0733cd773034" returning
       new HttpResponse[String]("<result><bag-info><urn>urn:nbn:nl:ui:13-z4-f8cm</urn><doi>10.5072/dans-2xg-umq8</doi></bag-info></result>", 200, Map.empty)
     val appConfig = testConfig(delegatingBagIndex(delegate), null)
-    (appConfig.maybePreStagedProvider.get.get(_: String, _: Int)) expects(*, 1) returning Success(Seq.empty)
+    (appConfig.maybePreStagedProvider.get.get(_: String, _: Int)) expects(*, 2) returning Success(Seq.empty)
 
 
     (resourceBags / vaultUUID).copyTo(testDir / "exports" / vaultUUID)

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
@@ -85,7 +85,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |Is-Version-Of: $versionOfUuid
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), 1, None))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), 2, None))
   }
   it should "have a base-urn" in {
     val bagUuid = UUID.randomUUID()
@@ -99,6 +99,6 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
          |${ BagInfo.baseDoiKey }: lalala
          |EASY-User-Account: user001
          |""".stripMargin)
-    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), 1, Some(BasePids("rabarbera", "lalala"))))
+    BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, bagUuid, "bag-name", Some(versionOfUuid), 2, Some(BasePids("rabarbera", "lalala"))))
   }
 }


### PR DESCRIPTION
Fixes DD-723 missing pre-staged files

When applied it will
--------------------
* use 2 as default Bag-sequence-nr when bag-infotxt has an Is-version-of
* This is a workaround for easy-fedora-to-bag not producing Bag-sequence-nr for original versioned bags. It will still be a problem when a dataset has more than two versions an the Bag-sequence-nr is missing.
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------


Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
