### PR TITLE
DD-771: Use 'Created' from the bag-info.txt instead of 'Bagging-Date'

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/BagInfo.scala
@@ -58,7 +58,7 @@ object BagInfo {
     val maybeSeqNr = Option(bagInfo.get(BagFacade.BAG_SEQUENCE_NUMBER)).flatMap(_.asScala.headOption)
     new BagInfo(
       userId = getMandatory(BagFacade.EASY_USER_ACCOUNT_KEY),
-      created = getMandatory("Bagging-Date"),
+      created = getMandatory("Created"),
       uuid = uuidFromFile(bagDir.parent),
       bagName = bagDir.name,
       versionOf = maybeVersionOf,

--- a/src/test/resources/bags/01/not-a-uuid/bag-name/bag-info.txt
+++ b/src/test/resources/bags/01/not-a-uuid/bag-name/bag-info.txt
@@ -1,2 +1,2 @@
 EASY-User-Account: user001
-Bagging-Date: 2016-06-07
+Created: 2016-06-07T11:45:06.371Z

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/BagInfoSpec.scala
@@ -42,7 +42,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val bagDir = (testDir / s"0$uuid" / "bag-name").createDirectories()
     val file = (bagDir / "bag-info.txt").write("EASY-User-Account: user001")
     BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Failure(InvalidBagException(
-      s"No Bagging-Date in $file"
+      s"No Created in $file"
     ))
   }
   it should "complain about missing user account" in {
@@ -58,7 +58,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val bagDir = (testDir / uuid.toString / "bag-name").createDirectories()
     (bagDir / "bag-info.txt").write(
       s"""EASY-User-Account: user001
-         |Bagging-Date: 2017-01-16T14:35:00.888+01:00
+         |Created: 2017-01-16T14:35:00.888+01:00
          |Is-Version-Of: urn:uuid:123456789$uuid
          |""".stripMargin)
     BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Failure(InvalidBagException(
@@ -70,7 +70,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val bagDir = (testDir / s"$uuid" / "bag-name").createDirectories()
     val dateTime = """2017-01-16T14:35:00.888+01:00"""
     (bagDir / "bag-info.txt").write(
-      s"""Bagging-Date: $dateTime
+      s"""Created: $dateTime
          |EASY-User-Account: user001
          |""".stripMargin)
     BagInfo(bagDir, mockBag(bagDir).getMetadata) shouldBe Success(new BagInfo("user001", dateTime, uuid, "bag-name", None, 1, None))
@@ -81,7 +81,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val bagDir = (testDir / s"$bagUuid" / "bag-name").createDirectories()
     val dateTime = """2017-01-16T14:35:00.888+01:00"""
     (bagDir / "bag-info.txt").write(
-      s"""Bagging-Date: $dateTime
+      s"""Created: $dateTime
          |Is-Version-Of: $versionOfUuid
          |EASY-User-Account: user001
          |""".stripMargin)
@@ -93,7 +93,7 @@ class BagInfoSpec extends AnyFlatSpec with Matchers with AppConfigSupport with B
     val bagDir = (testDir / s"$bagUuid" / "bag-name").createDirectories()
     val dateTime = """2017-01-16T14:35:00.888+01:00"""
     (bagDir / "bag-info.txt").write(
-      s"""Bagging-Date: $dateTime
+      s"""Created: $dateTime
          |Is-Version-Of: $versionOfUuid
          |${ BagInfo.baseUrnKey }: rabarbera
          |${ BagInfo.baseDoiKey }: lalala

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactorySpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/DepositPropertiesFactorySpec.scala
@@ -49,7 +49,7 @@ class DepositPropertiesFactorySpec extends AnyFlatSpec with Matchers with AppCon
       s"""state.label = SUBMITTED
          |state.description = This deposit was extracted from the vault and is ready for processing
          |deposit.origin = VAULT
-         |creation.timestamp = 2016-06-07
+         |creation.timestamp = 2017-01-16T14:35:00.888+01:00
          |depositor.userId = user001
          |identifier.doi = 10.5072/dans-2xg-umq8
          |identifier.urn = urn:nbn:nl:ui:13-00-3haq


### PR DESCRIPTION
Fixes DD-771

When applied it will
--------------------
* Use 'Created' from the bag-info.txt instead of 'Bagging-Date'
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
