### PR TITLE
DD-811: part two - fix unit test with published schemas

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -29,9 +29,10 @@ import scala.util.{Success, Try}
 import scala.xml.XML
 
 class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSupport with FileSystemSupport with SchemaSupport {
-  private val defaultLocation = "https://easy.dans.knaw.nl/schemas"
+  // use actual location (and replace in validated XML) when upgraded schema is not yet published
   private val actualLocation = "https://raw.githubusercontent.com/DANS-KNAW/easy-schema/DD-811-encoding/lib/src/main/resources"
-  override val schema: String = actualLocation + "/bag/metadata/prov/provenance.xsd"
+  private val defaultLocation = "https://easy.dans.knaw.nl/schemas"
+  override val schema: String = defaultLocation + "/bag/metadata/prov/provenance.xsd"
 
   private val resourceBags: File = File("src/test/resources/bags/01")
   private val validUUID = "04e638eb-3af1-44fb-985d-36af12fccb2d"
@@ -111,9 +112,9 @@ class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSu
       (include("<depositorId>USer</depositorId>") and not include "<depositorId>user001</depositorId>")
 
     assume(schemaIsAvailable)
-    val xmlString = File("src/test/resources/encoding/ddm-in.xml")
+    val xmlString = File("src/test/resources/encoding/provenance.xml")
       .contentAsString(Charset.forName("UTF-8"))
-      .replaceAll(" " + defaultLocation, " " + actualLocation)
+//      .replaceAll(" " + defaultLocation, " " + actualLocation)
     validate(XML.loadString(xmlString))
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
@@ -26,9 +26,10 @@ import java.nio.charset.Charset
 import scala.xml.{Utility, XML}
 
 class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport with Matchers with FixedCurrentDateTimeSupport with DebugEnhancedLogging with SchemaSupport {
-  private val defaultLocation = "https://easy.dans.knaw.nl/schemas"
+  // use actual location (and replace in validated XML) when upgraded scheme is not yet published
   private val actualLocation = "https://raw.githubusercontent.com/DANS-KNAW/easy-schema/DD-811-encoding/lib/src/main/resources"
-  override val schema: String = actualLocation + "/bag/metadata/prov/provenance.xsd"
+  private val defaultLocation = "https://easy.dans.knaw.nl/schemas"
+  override val schema: String = defaultLocation + "/bag/metadata/prov/provenance.xsd"
 
   "Provenance" should "show encoding changes" in {
     val ddmOut = XML.loadFile("src/test/resources/encoding/ddm-out.xml")
@@ -45,9 +46,9 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
       normalized(XML.loadFile("src/test/resources/encoding/provenance.xml"))
 
     assume(schemaIsAvailable)
-    val xmlString = File("src/test/resources/encoding/ddm-in.xml")
+    val xmlString = File("src/test/resources/encoding/provenance.xml")
       .contentAsString(Charset.forName("UTF-8"))
-      .replaceAll(" " + defaultLocation, " " + actualLocation)
+//      .replaceAll(" " + defaultLocation, " " + actualLocation)
     validate(XML.loadString(xmlString))
   }
   "compare" should "show ddm diff" in {


### PR DESCRIPTION
Fixes DD-811: part two - fix unit test with published schemas

When applied it will
--------------------
* with third party schemas back online the last step (validation of generated XML) of two tests were no longer ignored but broken
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------
* [x] ran `mvn clean install` witout `-DskipTests `

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
