### PR TITLE
DD-1140 valid provenance (CDATA for provenance//old)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/Provenance.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bag2deposit/ddm/Provenance.scala
@@ -61,7 +61,7 @@ object Provenance extends DebugEnhancedLogging {
     if (onlyInOld.isEmpty && onlyInNew.isEmpty) None
     else Some(
       <prov:file scheme={ scheme }>
-        <prov:old>{ onlyInOld }</prov:old>
+        <prov:old>{ PCData(onlyInOld.mkString("\n")) }</prov:old>
         <prov:new>{ onlyInNew }</prov:new>
       </prov:file>.copy(scope = oldXml.scope) // TODO in case of ddm perhaps also dc[t[erms]] and dcx-gml?
     )

--- a/src/test/resources/encoding/provenance.xml
+++ b/src/test/resources/encoding/provenance.xml
@@ -13,13 +13,7 @@
             </prov:new>
         </prov:file>
         <prov:file scheme="http://easy.dans.knaw.nl/schemas/md/ddm/">
-            <prov:old>
-                <dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/">
-                    <Point xmlns="http://www.opengis.net/gml">
-                        <pos>0 0</pos>
-                    </Point>
-                </dcx-gml:spatial>
-            </prov:old>
+            <prov:old><![CDATA[<dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"><Point xmlns="http://www.opengis.net/gml"><pos>0 0</pos></Point></dcx-gml:spatial>]]></prov:old>
             <prov:new>
             </prov:new>
         </prov:file>

--- a/src/test/resources/funder/provenance.xml
+++ b/src/test/resources/funder/provenance.xml
@@ -4,7 +4,7 @@
         xmlns:prov="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/">
     <prov:migration app="EasyConvertBagToDepositApp" version="1.0.5" date="2020-02-02">
         <prov:file scheme="http://easy.dans.knaw.nl/schemas/md/ddm/">
-            <prov:old>
+            <prov:old><![CDATA[
                 <dcx-dai:contributorDetails
                         xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/">
                     <dcx-dai:author>
@@ -37,7 +37,7 @@
                         <dcx-dai:role>Funder</dcx-dai:role>
                     </dcx-dai:organization>
                 </dcx-dai:contributorDetails>
-            </prov:old>
+            ]]></prov:old>
             <prov:new>
                 <dcx-dai:contributorDetails
                         xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/">

--- a/src/test/resources/funder/provenance.xml
+++ b/src/test/resources/funder/provenance.xml
@@ -1,3 +1,8 @@
+<prov:provenance
+        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/ https://easy.dans.knaw.nl/schemas/bag/metadata/prov/provenance.xsd"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:prov="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/">
+    <prov:migration app="EasyConvertBagToDepositApp" version="1.0.5" date="2020-02-02">
         <prov:file scheme="http://easy.dans.knaw.nl/schemas/md/ddm/">
             <prov:old>
                 <dcx-dai:contributorDetails
@@ -77,3 +82,5 @@
                 </ddm:funding>
             </prov:new>
         </prov:file>
+    </prov:migration>
+</prov:provenance>

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/SchemaSupport.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/Fixture/SchemaSupport.scala
@@ -55,7 +55,7 @@ trait SchemaSupport {
 
   def validate(xml: Node): Try[Unit] = {
     val serialized = Utility.serialize(xml).toString()
-    triedSchema.getOrElse(fail("Please prefix the test with 'assume(schemaIsAvailable)' to ignore a failure due to not reachable schema's"))
+    triedSchema.getOrElse(fail(s"Please prefix the test with 'assume(schemaIsAvailable)' to ignore a failure due to not reachable schema's ${triedSchema.toEither.left.get}"))
     triedSchema.flatMap { schema =>
       val source = new StreamSource(serialized.inputStream)
       Try(schema.newValidator().validate(source))

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
@@ -62,18 +62,14 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
         Provenance.compare((ddmIn \ "profile").head, (ddmOut \ "profile").head, ddmSchema),
         Provenance.compare((ddmIn \ "dcmiMetadata").head, (ddmOut \ "dcmiMetadata").head, ddmSchema),
       ))
-
-    val actual = Utility.trim(provenance)
     val expected = Utility.trim(XML.loadFile("src/test/resources/encoding/provenance.xml"))
-    actual.text shouldBe expected.text
-//    closingTags(actual) shouldBe closingTags(expected)
 
-    Seq(ddmIn.scope) shouldNot be(empty)
-    (provenance \\ "file").map(_.scope).mkString("") shouldBe ddmIn.scope.toString()
+    // CDATA is turned into escaped strings when comparing the full XML
+    // trick does not work for funder test, perhaps because here we have multiple CDATA elements
+    (provenance \\ "migration").map(Utility.trim) shouldBe (expected \\ "migration").map(Utility.trim)
 
     assume(schemaIsAvailable)
-    validate(provenance)
-    validate(XML.loadFile("src/test/resources/encoding/provenance.xml")) shouldBe a[Success[_]]
+    validate(provenance) shouldBe a[Success[_]]
   }
   it should "show ddm diff" in {
     val ddmIn = {
@@ -262,8 +258,7 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
 
     (Utility.trim(actual) \\ "old").text.replaceAll("\n","").replaceAll("><","> <") shouldBe
       (Utility.trim(expected) \\ "old").text // might break when attributes are serialized in different order
-    normalized((actual \\ "new").head) shouldBe
-      normalized((expected \\ "new").head)
+    normalized((actual \\ "new").head) shouldBe normalized((expected \\ "new").head)
     assume(schemaIsAvailable)
     validate(actual) shouldBe a[Success[_]]
   }
@@ -392,10 +387,8 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
       Provenance.compare(amdIn, amdOut, amdSchema),
     ))
 
-    (provenance \\ "old").text shouldBe
-      (expected \\ "old").text // might break when attributes are serialized in different order
-    normalized((provenance \\ "new").head) shouldBe
-      normalized((expected \\ "new").head)
+    (provenance \\ "old").text shouldBe (expected \\ "old").text // might break when attributes are serialized in different order
+    normalized((provenance \\ "new").head) shouldBe normalized((expected \\ "new").head)
     val actual = Utility.trim(provenance)
     actual.text shouldBe expected.text
     closingTags(actual) shouldBe closingTags(expected)

--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
@@ -286,16 +286,21 @@ class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport 
       ddmSchema
     )))
 
-    normalized((provenance \\ "file").head) shouldBe normalized(expected)
+    normalized((provenance \\ "file").head) shouldBe normalized((expected \\ "file").head)
 
     val actual = Utility.trim(provenance)
     actual.text shouldBe expected.text
-    closingTags(actual) shouldBe closingTags(<prov:provenance><prov:migration>{ expected }</prov:migration></prov:provenance>)
+    closingTags(actual) shouldBe closingTags(expected)
+
+    println(printer.format(Utility.trim(actual)))
 
     assume(schemaIsAvailable)
     // see PR #78 issue DD-806 claims it are only one or two datasets
     parseError(Utility.serialize(actual).toString()) shouldBe
-      """org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1376; cvc-enumeration-valid: Value 'Funder' is not facet-valid with respect to enumeration '[ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, HostingInstitution, Other, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, ResearchGroup, RightsHolder, Researcher, Sponsor, Supervisor, WorkPackageLeader]'. It must be a value from the enumeration."""
+    """org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1376; cvc-enumeration-valid: Value 'Funder' is not facet-valid with respect to enumeration '[ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, HostingInstitution, Other, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, ResearchGroup, RightsHolder, Researcher, Sponsor, Supervisor, WorkPackageLeader]'. It must be a value from the enumeration."""
+
+    parseError(Utility.serialize(expected).toString()) shouldBe
+      """org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1057; cvc-enumeration-valid: Value 'Funder' is not facet-valid with respect to enumeration '[ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, HostingInstitution, Other, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, ResearchGroup, RightsHolder, Researcher, Sponsor, Supervisor, WorkPackageLeader]'. It must be a value from the enumeration."""
   }
 
   it should "show amd diff" in {


### PR DESCRIPTION
Fixes DD-1140 valid provenance (CDATA for provenance//old)

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------
* [ ] ran `mvn clean install` witout `-DskipTests `

Related pull requests on github
-------------------------------

* [x] requires https://github.com/DANS-KNAW/easy-schema/pull/112