### PR TITLE
DD-1140: restored public schema in ProvenanceSpec

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/ddm/ProvenanceSpec.scala
@@ -27,8 +27,7 @@ import scala.xml.{ Utility, XML }
 
 class ProvenanceSpec extends AnyFlatSpec with FileSystemSupport with XmlSupport with Matchers with FixedCurrentDateTimeSupport with DebugEnhancedLogging with SchemaSupport with AppConfigSupport {
   // use the raw github location while upgraded schema is not yet published, your own fork if not yet merged.
-  private val schemaRoot = "https://raw.githubusercontent.com/DANS-KNAW-jp/easy-schema/valid-provenance/lib/src/main/resources"
-//  private val schemaRoot = "https://easy.dans.knaw.nl/schemas"
+  private val schemaRoot = "https://easy.dans.knaw.nl/schemas"
   override val schema: String = schemaRoot + "/bag/metadata/prov/provenance.xsd"
   private val schemaLocation = s"http://easy.dans.knaw.nl/schemas/bag/metadata/prov/ $schema"
   private val ddmSchema = "http://easy.dans.knaw.nl/schemas/md/ddm/"


### PR DESCRIPTION
Fixes DD-1140: restored public schema in ProvenanceSpec

When applied it will
--------------------
* 
* 
* 

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------
* [x] ran `mvn clean install` witout `-DskipTests `

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
