### PR TITLE
Fixed problems in unit test that show up when building under Linux

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bag2deposit/AppSpec.scala
@@ -301,7 +301,7 @@ class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSu
     ) shouldBe Success("No fatal errors")
 
     val movedBag = testDir / "ingest-dir" / validUUID / "bag-revision-1"
-    (movedBag / "data").list.toSeq.map(_.name) shouldBe Seq("easy-migration", "foo.txt")
+    (movedBag / "data").list.map(_.name).toSet shouldBe Set("easy-migration", "foo.txt")
     (movedBag / "manifest-sha1.txt").contentAsString should include("foo.txt")
   }
 
@@ -329,7 +329,7 @@ class AppSpec extends AnyFlatSpec with XmlSupport with Matchers with AppConfigSu
     ) shouldBe Success("No fatal errors")
 
     val movedBag = testDir / "ingest-dir" / validUUID / "bag-revision-1"
-    (movedBag / "data").list.toSeq.map(_.name) shouldBe Seq("easy-migration", "foo.txt")
+    (movedBag / "data").list.map(_.name).toSet shouldBe Set("easy-migration", "foo.txt")
     (movedBag / "manifest-sha1.txt").contentAsString should include("foo.txt")
   }
 


### PR DESCRIPTION
NO JIRA

When applied it will
--------------------
Replace list comparison with set comparison in some unit tests. Under Linux the order of the to lists was different than on the Mac, apparently. However, the order is actually not important.

Where should the reviewer @DANS-KNAW/easy start?
------------------------------------------------

How should this be manually tested?
-----------------------------------
* [ ] ran `mvn clean install` witout `-DskipTests `

Related pull requests on github
-------------------------------

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
